### PR TITLE
add type annotations and some formatting to part of the code

### DIFF
--- a/delta_remote/original_delta_example.py
+++ b/delta_remote/original_delta_example.py
@@ -4,27 +4,38 @@ import socket
 
 SUPPLY_IP = "192.168.2.90"
 SUPPLY_PORT = 8462
-BUFFER_SIZE = 128 # max msg size
-TIMEOUT_SECONDS = 10 # return error if we dont hear from supply within 10 sec
-MAX_VOLT = 10 # default
-MAX_CUR = 10    #default
-validSrcList = ["front", "web", "seq", "eth", "slot1", "slot2", "slot3", "slot4", "loc", "rem"]
+BUFFER_SIZE = 128  # max msg size
+TIMEOUT_SECONDS = 10  # return error if we dont hear from supply within 10 sec
+MAX_VOLT = 10  # default
+MAX_CUR = 10  # default
+validSrcList = [
+    "front",
+    "web",
+    "seq",
+    "eth",
+    "slot1",
+    "slot2",
+    "slot3",
+    "slot4",
+    "loc",
+    "rem",
+]
 
 
-supplySocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM) # set up socket
-supplySocket.connect((SUPPLY_IP, SUPPLY_PORT)) # connect socket
+supplySocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # set up socket
+supplySocket.connect((SUPPLY_IP, SUPPLY_PORT))  # connect socket
 supplySocket.settimeout(TIMEOUT_SECONDS)
 
 
 def sendAndReceiveCommand(msg):
-    msg =  msg + "\n"
+    msg = msg + "\n"
     supplySocket.sendall(msg.encode("UTF-8"))
     return supplySocket.recv(BUFFER_SIZE).decode("UTF-8").rstrip()
 
 
 # set value without receiving a response
 def sendCommand(msg):
-    msg =  msg + "\n"
+    msg = msg + "\n"
     supplySocket.sendall(msg.encode("UTF-8"))
 
 
@@ -60,6 +71,7 @@ def setCurrent(cur):
 def readVoltage():
     return sendAndReceiveCommand("SOUR:VOLT?")
 
+
 def readCurrent():
     return sendAndReceiveCommand("SOUR:CUR?")
 
@@ -91,8 +103,10 @@ def setOutputState(state):
     else:
         sendCommand("OUTPUT 0")
 
+
 def closeSocket():
     supplySocket.close()
+
 
 if __name__ == "__main__":
     print(sendAndReceiveCommand("*IDN?"))
@@ -101,16 +115,13 @@ if __name__ == "__main__":
 
     print(MAX_VOLT, MAX_CUR)
 
-
     setProgSourceV("eth")
     setProgSourceI("eth")
 
     setVoltage(12.23)
     setCurrent(43.01)
 
-    setRemoteShutdownState(0) # RSD Enabled = supply off/disabled
+    setRemoteShutdownState(0)  # RSD Enabled = supply off/disabled
     print(readVoltage())
     print(readCurrent())
     closeSocket()
-
-

--- a/delta_remote/script_wrapper.py
+++ b/delta_remote/script_wrapper.py
@@ -23,16 +23,17 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTIO
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
 THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
- 
+
 from enum import Enum
 import re
 
+
 class DeltaSCPIError(Exception):
-    """ Delta Connection Exception Class
-    
+    """Delta Connection Exception Class
+
     This exception is thrown when an error occurs with the communication,
     which has not yet been thrown by a socket exception.
-    
+
     After this error the connection must be completely rebuilt.
     """
 
@@ -40,11 +41,13 @@ class DeltaSCPIError(Exception):
         self.message = message
         super().__init__(self.message)
 
+
 class DeltaSources(Enum):
-    """ Delta Elektronika power supply source options.
-    
+    """Delta Elektronika power supply source options.
+
     The class manages the possible sources to be used for setting the target voltage and current.
     """
+
     front = "front"
     web = "web"
     seq = "seq"
@@ -55,126 +58,126 @@ class DeltaSources(Enum):
     slot4 = "slot4"
     loc = "loc"
     rem = "rem"
-    
- 
+
+
 class DeltaSCPIWrapper(object):
-    """ Class containing the SCPI commands for the Delta Elektronika power supply.
-    
+    """Class containing the SCPI commands for the Delta Elektronika power supply.
+
     This class wraps the SCPI commands in getter and setter methods.
-        
+
     :param connection: The connection object to the Delta power supply.
     :type connection: :class:`~delta_remote.connection.DeltaConnection`
     """
- 
+
     def __init__(self, connection):
         self.defaultTimeout = None
         self.connection = connection
-        
+
         self.maximumVoltage = self._requestFloatValue("SOUR:VOLT:MAX?")
         self.maximumCurrent = self._requestFloatValue("SOUR:CUR:MAX?")
         return
-        
+
     def setDefaultTimout(self, time):
-        """ Set the default timeout.
+        """Set the default timeout.
 
         The command sets the default timeout that is used.
-        
+
         :param time: Timout in seconds.
-        """    
+        """
         self.defaultTimeout = time
         return
-    
+
     def IDN(self):
-        """ Querying the device identification.
-        
+        """Querying the device identification.
+
         This is the standard SCPI command for requesting the identification.
-        
+
         :returns: The response string from the device.
         """
         return self.executeCommandAndWaitForReply("*IDN?")
-    
+
     def setTargetVoltage(self, value):
-        """ Set the target output voltage.
-        
+        """Set the target output voltage.
+
         :param value: The output voltage.
         """
         if value >= 0 and value <= self.maximumVoltage:
             self.executeCommand(f"SOUR:VOLT {value}")
         else:
             raise DeltaSCPIError("Voltage out of range.")
-        return 
-    
+        return
+
     def setTargetCurrent(self, value):
-        """ Set the target output current.
-        
+        """Set the target output current.
+
         :param value: The output current.
         """
         if value >= 0 and value <= self.maximumCurrent:
             self.executeCommand(f"SOUR:CUR {value}")
         else:
             raise DeltaSCPIError("Voltage out of range.")
-        return 
-    
+        return
+
     def getTargetVoltage(self):
-        """ Read the target output voltage.
-        
+        """Read the target output voltage.
+
         :returns: The value.
         """
         return self._requestFloatValue("SOUR:VOLT?")
-    
+
     def getTargetCurrent(self):
-        """ Read the target output current.
-        
+        """Read the target output current.
+
         :returns: The value.
         """
         return self._requestFloatValue("SOUR:CUR?")
-    
+
     def getMeasuredVoltage(self):
-        """ Measure the actual output voltage.
-        
+        """Measure the actual output voltage.
+
         :returns: The value.
         """
         return self._requestFloatValue("MEAS:VOLT?")
-    
+
     def getMeasuredCurrent(self):
-        """ Measure the actual output current.
-        
+        """Measure the actual output current.
+
         :returns: The value.
         """
         return self._requestFloatValue("MEAS:CUR?")
-        
+
     def getMeasuredPower(self):
-        """ Measure the actual output power.
-        
+        """Measure the actual output power.
+
         :returns: The value.
         """
         return self._requestFloatValue("MEAS:POW?")
-    
+
     def setProgSourceVoltage(self, source: DeltaSources):
-        """ Set the voltage source option.
-        
+        """Set the voltage source option.
+
         Defines which interface defines the voltage to be applied.
-        
+
         :param source: The source option.
         :type source: :class:`~delta_remote.script_wrapper.DeltaSources`
         """
         self.executeCommand(f"SYST:REM:CV {source.value}")
         return
-    
+
     def setProgSourceCurrent(self, source: DeltaSources):
-        """ Set the current source option.
-        
+        """Set the current source option.
+
         Defines which interface defines the current to be applied.
-        
+
         :param source: The source option.
         :type source: :class:`~delta_remote.script_wrapper.DeltaSources`
         """
         self.executeCommand(f"SYST:REM:CC {source.value}")
         return
-    
-    def enableOutput(self, enable = True):
-        """ Enable the output of the supply.
-        
+
+    def enableOutput(self, enable=True):
+        """Enable the output of the supply.
+
         :param enable: True to turn the output on.
         """
         if enable:
@@ -182,39 +185,38 @@ class DeltaSCPIWrapper(object):
         else:
             self.executeCommand("OUTPUT 0")
         return
-    
+
     def disableOutput(self):
-        """ Disable the output of the supply.
-        
-        """
+        """Disable the output of the supply."""
         self.enableOutput(False)
         return
-        
-    def executeCommand(self, command, timeout = None):
-        """ Executes a command.
-        
+
+    def executeCommand(self, command, timeout=None):
+        """Executes a command.
+
         :param command: The command.
         :param timeout: The timeout for sending data in seconds, blocking at None.
         """
         if timeout is None:
             timeout = self.defaultTimeout
         return self.connection.sendTelegram(command + "\n", timeout)
-    
-    def executeCommandAndWaitForReply(self, command, timeout = None):
-        """ Executes a command and waits for the reply from the device.
-        
+
+    def executeCommandAndWaitForReply(self, command, timeout=None):
+        """Executes a command and waits for the reply from the device.
+
         :param command: The command.
         :param timeout: The timeout for sending data in seconds, blocking at None.
         """
         if timeout is None:
             timeout = self.defaultTimeout
-        return self.connection.sendStringAndWaitForReplyString(command + "\n", timeout).rstrip()
-    
+        return self.connection.sendStringAndWaitForReplyString(
+            command + "\n", timeout
+        ).rstrip()
+
     def _requestValueAndParseUsingRegexp(self, command, pattern):
         reply = self.executeCommandAndWaitForReply(command)
         match = re.search(pattern, reply)
         return float(match.group(1))
-    
-    def _requestFloatValue(self,command):
-        return float(self.executeCommandAndWaitForReply(command))
 
+    def _requestFloatValue(self, command):
+        return float(self.executeCommandAndWaitForReply(command))

--- a/thales_remote/__init__.py
+++ b/thales_remote/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['connection', 'error', 'file_interface', 'script_wrapper']
+__all__ = ["connection", "error", "file_interface", "script_wrapper"]

--- a/thales_remote/connection.py
+++ b/thales_remote/connection.py
@@ -29,6 +29,7 @@ import time
 import struct
 import threading
 import queue
+from typing import Optional, Union, Any
 from _socket import SHUT_RD
 from thales_remote.error import TermConnectionError
 
@@ -39,142 +40,158 @@ class ThalesRemoteConnection(object):
     """
     Class to handle the Thales remote connection.
     """
-    
+
+    _term_port: int
+    _socket_handle: Optional[socket.socket]
+    _receiving_worker: Optional[threading.Thread]
+    _send_mutex: threading.Semaphore
+    _receiving_worker_is_running: bool
+    _available_channels: list[int]
+    _queuesForChannels: dict[int, queue.Queue[Optional[bytes]]]
+    _connectionName: str
+
     def __init__(self):
-        self.term_port = 260  # The port used by Thales
-        self.socket_handle = None
-        
-        self.receivingWorker = None
-        
-        self.sendMutex = threading.Semaphore(1)
-        
+        self._term_port = 260  # The port used by Thales
+        self._socket_handle = None
+        self._receiving_worker = None
+        self._send_mutex = threading.Semaphore(1)
         self._receiving_worker_is_running = False
-        
-        self.availibleChannels = [2,128,129,130,131,132]
-        
-        self.queuesForChannels = dict()
-        
-        for channel in self.availibleChannels:
-            self.queuesForChannels[channel] = queue.Queue()
-        
-        self.connectionName = ""
-        return
-        
-    def connectToTerm(self, address, connectionName = "ScriptRemote"):
-        """ Connect to Term Software.
-        
-        
-        :param address: The hostname or ip-address of the host running Term.
-        :param connectionName: The name of the connection ScriptRemote for Remote and Logging as Online Display.
-        :returns: True on success, False if failed.
-        :rtype: bool
+        self._available_channels = [2, 128, 129, 130, 131, 132]
+        self._queuesForChannels = dict()
+
+        for channel in self._available_channels:
+            self._queuesForChannels[channel] = queue.Queue()
+
+        self._connectionName = ""
+
+    def connectToTerm(
+        self, address: str, connection_name: str = "ScriptRemote"
+    ) -> bool:
         """
-        self.socket_handle = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        Connect to Term Software.
+
+        TODO:
+            - should raise exception on failure – returning bools is C-style error handling
+
+        :param address: hostname or ip-address of the host running "Term" application
+        :param connection_name: name of the connection ScriptRemote for Remote and Logging as Online Display
+        :returns: True on success, False on failure
+        """
+        self._socket_handle = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
-            self.socket_handle.connect((address, self.term_port))
+            self._socket_handle.connect((address, self._term_port))
         except:
-            self.socket_handle = None
+            self._socket_handle = None
             return False
-            
+
         self._startTelegramListener()
-        
+
         time.sleep(0.4)
-        
-        self.connectionName = connectionName
-        payload_length = len(connectionName)
-        
+
+        self._connectionName = connection_name
+        payload_length = len(connection_name)
+
         registration_packet = bytearray()
-        registration_packet += bytearray(struct.pack('<H', payload_length))
-        registration_packet += bytearray([0x02, 0xd0, 0xff, 0xff, 0xff, 0xff])
-        registration_packet += bytearray(connectionName, 'ASCII')
-        
+        registration_packet += bytearray(struct.pack("<H", payload_length))
+        registration_packet += bytearray([0x02, 0xD0, 0xFF, 0xFF, 0xFF, 0xFF])
+        registration_packet += bytearray(connection_name, "ASCII")
+
         # print("\n" + str(datetime.now().time()) + " send:")
         # print(f"payload_length: {payload_length}")
         # print(f"registration_packet: {registration_packet}")
         # print("complete packet:" + str(registration_packet))
-        
-        self.sendMutex.acquire()
-        self.socket_handle.sendall(registration_packet)
-        self.sendMutex.release()
-        
+
+        self._send_mutex.acquire()
+        self._socket_handle.sendall(registration_packet)
+        self._send_mutex.release()
+
         time.sleep(0.8)
-        
+
         return True
-    
-    def getConnectionName(self):
-        """ Get the connection name
-        
-        :returns: The name of the connection.
-        :rtype: str
+
+    def getConnectionName(self) -> str:
         """
-        return self.connectionName
-            
-    def disconnectFromTerm(self):
-        """ Close the connection to Term and cleanup.
-        
+        get the connection name
+
+        :returns: name of the connection
+        """
+        return self._connectionName
+
+    def disconnectFromTerm(self) -> None:
+        """
+        close the connection to Term and cleanup
+
         Stops the thread used for receiving telegrams assynchronously and shuts down
         the network connection. Put None into the Queues to free the waiting threads.
         They wait in waitForBinaryTelegram and if they receive None from the Queue, the will throw an exception.
         """
-        self.sendStringAndWaitForReplyString("3," + str(self.connectionName) + ",0,RS", 128)
+        self.sendStringAndWaitForReplyString(
+            "3," + str(self._connectionName) + ",0,RS", 128
+        )
         time.sleep(0.2)
-        self.sendTelegram(bytearray([255,255]), 4)
+        self.sendTelegram(bytearray([255, 255]), 4)
         time.sleep(0.2)
         self._stopTelegramListener()
         time.sleep(0.2)
         self._closeSocket()
-        for key in self.queuesForChannels.keys():
-            self.queuesForChannels[key].put(None)
+        for key in self._queuesForChannels.keys():
+            self._queuesForChannels[key].put(None)
         return
-        
-    def isConnectedToTerm(self):
-        """Check if the connection to Term is open.
-        
-        :returns: True if connected, False if not.
-        :rtype: bool
+
+    def isConnectedToTerm(self) -> bool:
         """
-        return self.socket_handle != None
-            
-    def sendTelegram(self, payload, message_type, timeout=None):
-        """Send a telegram (data) to Term.
-        
+        check if the connection to Term is open
+
+        :returns: True if connected, False otherwise
+        """
+        return self._socket_handle != None
+
+    def sendTelegram(
+        self,
+        payload: Union[str, bytearray],
+        message_type: int,
+        timeout: Optional[float] = None,
+    ) -> None:
+        """
+        send a telegram (data) to Term
+
         Sending a telegram to the term.
         If the other thread hangs while sending and the semaphore cannot be aquired within the timout,
         then a TermConnectionError is thrown. If a timeout occurs in the socket,
         then an exception is thrown by the socket.
-        
+
         :param payload: The actual data which is being sent to Term. This can be a string or an bytearray.
         :param message_type: Used internally by the DevCli dll. Depends on context. Most of the time 2.
         :param timeout: The timeout for sending data in seconds, blocking at None.
         """
         packet = bytearray()
         data = bytearray()
-        
-        if(isinstance(payload, str)):
+
+        if isinstance(payload, str):
             # datatype string
             payload_length = len(payload)
-            data += bytearray(payload, 'ASCII')
+            data += bytearray(payload, "ASCII")
         else:
             # datatype bytearray
             payload_length = len(payload)
             data = payload
-        
-        packet += bytearray(struct.pack('<H', payload_length))
-        packet += bytearray(struct.pack('<B', message_type))
+
+        packet += bytearray(struct.pack("<H", payload_length))
+        packet += bytearray(struct.pack("<B", message_type))
         packet += data
-        
-        if self.sendMutex.acquire(True,timeout=timeout):
-            self.socket_handle.settimeout(timeout)
+
+        if self._send_mutex.acquire(True, timeout=timeout):
+            self._socket_handle.settimeout(timeout)
             try:
                 # print("\n" + str(datetime.now().time()) + " send:")
                 # print(f"payload_length: {payload_length} message_type: {message_type}")
                 # print(f"payload: {data}")
                 # print("complete packet:" + str(packet))
-                
-                self.socket_handle.sendall(packet)
+
+                self._socket_handle.sendall(packet)
             finally:
-                self.socket_handle.settimeout(None)
-                self.sendMutex.release()
+                self._socket_handle.settimeout(None)
+                self._send_mutex.release()
         else:
             """
             The semaphore to send could not be aquired within the timeout.
@@ -182,119 +199,135 @@ class ThalesRemoteConnection(object):
             """
             raise TermConnectionError("Socket error during data transmission.")
         return
-    
-    
-    def waitForBinaryTelegram(self, message_type=2, timeout=None):
-        """ Block infinitely until the next Telegram is arriving.
-        
+
+    def waitForBinaryTelegram(
+        self, message_type: int = 2, timeout: Optional[float] = None
+    ) -> bytes:
+        """
+        block infinitely until the next Telegram is arriving
+
         If some Telegram has already arrived it will just return the last one from the queue.
-        
+
         :param message_type: Used internally by the DevCli dll. Depends on context. Most of the time 2.
         :param timeout: The timeout for sending data in seconds, blocking at None
         :returns: The response from the device or an empty bytearray if someting went wrong.
         :rtype: bytearray
         """
-        retval = self.queuesForChannels[message_type].get(True, timeout=timeout)
-        if retval == None:
+        retval = self._queuesForChannels[message_type].get(True, timeout=timeout)
+        if retval is None:
             raise TermConnectionError("Socket error during data reception.")
         return retval
-            
-    def waitForStringTelegram(self, message_type=2, timeout=None):
-        """ Block infinitely until the next Telegram is arriving.
-        
+
+    def waitForStringTelegram(
+        self, message_type: int = 2, timeout: Optional[float] = None
+    ) -> str:
+        """
+        block infinitely until the next Telegram is arriving
+
         If some Telegram has already arrived it will just return the last one from the queue.
-        
+
         :param message_type: Used internally by the DevCli dll. Depends on context. Most of the time 2.
         :param timeout: The timeout for sending data in seconds, blocking at None
         :returns: The last received telegram or an empty string if someting went wrong.
         :rtype: string
         """
-        retval = self.waitForBinaryTelegram(message_type,timeout).decode("ASCII")
+        retval = self.waitForBinaryTelegram(message_type, timeout).decode("ASCII")
         return retval
-        
-    def sendStringAndWaitForReplyString(self, payload, message_type, timeout=None, answer_message_type = None):
-        """ Convenience function: Send a telegram and wait for it's reply.
-        
+
+    def sendStringAndWaitForReplyString(
+        self,
+        payload: Union[str, bytearray],
+        message_type: int,
+        timeout: Optional[float] = None,
+        answer_message_type: int = None,
+    ) -> str:
+        """
+        convenience function: send a telegram and wait for it's reply
+
         If a timeout or a socket error occurs an exception is thrown.
-        
-        
+
+
         :param payload: The actual data which is being sent to Term. This can be a string or an bytearray.
         :param message_type: Used internally by the DevCli dll. Depends on context. Most of the time 2.
         :param timeout: The timeout for sending data in seconds, blocking at None.
         :returns: The last received telegram or an empty string if someting went wrong.
         :rtype: string
         """
-        if answer_message_type == None:
+        if answer_message_type is None:
             answer_message_type = message_type
         self.sendTelegram(payload, message_type, timeout)
         return self.waitForStringTelegram(answer_message_type, timeout)
-        
-    """
-    The following methods should not be called by the user.
-    They are marked with the prefix '_' after the Python convention for proteced.
-    """
-        
-    def _telegramListenerJob(self):
-        """ The method running in a separate thread, pushing the incomming packets into the queues.
+
+    # The following methods should not be called by the user.
+    # They are marked with the prefix '_' after the Python convention for proteced.
+
+    def _telegramListenerJob(self) -> None:
+        """
+        runs in a separate thread, pushing the incomming packets into the queues.
         """
         while self._receiving_worker_is_running:
             message_type, telegram = self._readTelegramFromSocket()
-            if len(telegram) > 0 and message_type in self.availibleChannels:
-                self.queuesForChannels[message_type].put(telegram)
-            elif message_type == None:
-                """
-                An error has occurred in the connection. None is passed into all queues to free
-                the waiting threads from the queue. If they have received None, they throw an exception.
-                The thread is then exited.
-                """
-                for key in self.queuesForChannels.keys():
-                    self.queuesForChannels[key].put(None)
+            if len(telegram) > 0 and message_type in self._available_channels:
+                self._queuesForChannels[message_type].put(telegram)
+            elif message_type is None:
+                # An error has occurred in the connection. None is passed into all queues to free
+                # the waiting threads from the queue. If they have received None, they throw an exception.
+                # The thread is then exited.
+                for key, value in self._queuesForChannels.items():
+                    value.put(None)
                 self._receiving_worker_is_running = False
         return
-            
-    def _startTelegramListener(self):
-        """ Starts the thread handling the asyncronously incoming data.
+
+    def _startTelegramListener(self) -> None:
+        """
+        starts the thread handling the asyncronously incoming data
         """
         self._receiving_worker_is_running = True
-        self.receivingWorker = threading.Thread(target=self._telegramListenerJob)
-        self.receivingWorker.start()
+        self._receiving_worker = threading.Thread(target=self._telegramListenerJob)
+        self._receiving_worker.start()
         return
-        
-    def _stopTelegramListener(self):
-        """ Stops the thread handling the incoming data gracefully.
+
+    def _stopTelegramListener(self) -> None:
         """
-        self.socket_handle.shutdown(SHUT_RD)
+        stops the thread handling the incoming data gracefully
+        """
+        self._socket_handle.shutdown(SHUT_RD)
         self._receiving_worker_is_running = False
-        self.receivingWorker.join()
+        self._receiving_worker.join()
         return
-            
-    def _readTelegramFromSocket(self):
-        """ Reads the raw telegram structure from the socket stream.
-        
+
+    def _readTelegramFromSocket(self) -> tuple[Optional[str], bytearray]:
+        """
+        reads the raw telegram structure from the socket stream
+
         When a socket exception occurs, None and an empty byte array are returned.
         The caller of the function then passes the None to the queue to raise an
         exception in the threads waiting at the queue.
         """
         try:
-            header_len = self.socket_handle.recv(2)
-            header_type_bytes = self.socket_handle.recv(1)
-            header_type = struct.unpack('<B', header_type_bytes)[0]
-            incoming_packet = self.socket_handle.recv(struct.unpack('<H', header_len)[0])
-            
+            header_len: bytes = self._socket_handle.recv(2)
+            header_type_bytes: bytes = self._socket_handle.recv(1)
+            header_type: str = struct.unpack("<B", header_type_bytes)[
+                0
+            ]  # actually a character, not a str
+            incoming_packet: int = self._socket_handle.recv(
+                struct.unpack("<H", header_len)[0]
+            )
+
             # print("\n" + str(datetime.now().time()) + " read:")
             # print(f"payload_length: {struct.unpack('<H', header_len)[0]} message_type: {header_type}")
             # print(f"payload: {incoming_packet}")
             # print("complete packet:" + str(header_len + header_type_bytes + incoming_packet))
-            
+
         except:
             header_type = None
             incoming_packet = bytearray()
         return header_type, incoming_packet
-            
-    def _closeSocket(self):
-        """ Close the socket.
+
+    def _closeSocket(self) -> None:
         """
-        self.socket_handle.close()
-        self.socket_handle = None
+        close the socket
+        """
+        self._socket_handle.close()
+        self._socket_handle = None
         return
-        

--- a/thales_remote/connection.py
+++ b/thales_remote/connection.py
@@ -29,11 +29,9 @@ import time
 import struct
 import threading
 import queue
-from typing import Optional, Union, Any
+from typing import Optional, Union
 from _socket import SHUT_RD
 from thales_remote.error import TermConnectionError
-
-from datetime import datetime
 
 
 class ThalesRemoteConnection(object):

--- a/thales_remote/error.py
+++ b/thales_remote/error.py
@@ -25,7 +25,6 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 
-
 """
 The following is an example for troubleshooting when an exception is thrown.
 
@@ -63,31 +62,32 @@ The first two lines of the traceback show the file and line number and the conte
 
 
 class ThalesRemoteError(Exception):
-    """ Thales Remote Exception Class
-    
+    """Thales Remote Exception Class
+
     This exception is thrown when an error is reported in the remote protocol, for example,
     when a parameter is out of range.
     In the following document the errors are explained.
     https://doc.zahner.de/manuals/remote2.pdf
     """
 
-    def __init__(self, message):
-        self.message = message
-        super().__init__(self.message)
-        
-        
-class TermConnectionError(Exception):
-    """ Term Connection Exception Class
-    
-    This exception is thrown when an error occurs with the term communication,
-    which has not yet been thrown by a socket exception.
-    
-    After this error the connection must be completely rebuilt.
-    """
+    message: str
 
     def __init__(self, message):
         self.message = message
         super().__init__(self.message)
-        
-        
-        
+
+
+class TermConnectionError(Exception):
+    """Term Connection Exception Class
+
+    This exception is thrown when an error occurs with the term communication,
+    which has not yet been thrown by a socket exception.
+
+    After this error the connection must be completely rebuilt.
+    """
+
+    message: str
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)

--- a/thales_remote/file_interface.py
+++ b/thales_remote/file_interface.py
@@ -26,277 +26,328 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import os
 import threading
-from thales_remote.connection import ThalesRemoteConnection
-from _queue import Empty
 import time
+from queue import Empty
+from typing import Optional, Union
+
+from thales_remote.connection import ThalesRemoteConnection
+
 
 class ThalesFileInterface(object):
-    """ Class which realizes the file transfer between Term software and Python.
-    
+    """Class which realizes the file transfer between Term software and Python.
+
     The measurement files cannot be stored on network drives with the Term software, therefore
     this class was implemented. If Python runs on another computer and controls Thales via network,
     then with this class the measurement result files can be exchanged via network.
-    
+
     This class establishes an additional socket connection to the Term, which can be used to transfer
     individual files manually. Or you can set that all ism, isc or isw files are transferred automatically
     at the end of the measurement.
-    
+
     :param address: IP address of the computer running the Term software.
     :param connectionName: The name of the connection default FileExchange. But can also be freely assigned.
     """
- 
-    def __init__(self, address, connectionName = "FileExchange"):
-        self._deviceName = connectionName
+
+    _device_name: str
+    remoteConnection: ThalesRemoteConnection
+    _receiver_is_running: bool
+    _automatic_file_exchange: bool
+    _files_to_skip: list[str]
+    receivedFiles: list[dict[str, Union[str, bytearray]]]
+    pathToSave: str
+    _save_received_files_to_disk: bool
+    _keep_files_in_object: bool
+
+    def __init__(self, address, connectionName="FileExchange"):
+        self._device_name = connectionName
         self.remoteConnection = ThalesRemoteConnection()
-        self.remoteConnection.connectToTerm(address, self._deviceName)
+        self.remoteConnection.connectToTerm(address, self._device_name)
         self._receiver_is_running = False
-        self._automaticFileExchange = False
-        self._filesToSkip = ["lastshot.ism"]
+        self._automatic_file_exchange = False
+        self._files_to_skip = ["lastshot.ism"]
         self.receivedFiles = []
         self.pathToSave = os.getcwd()
-        self._saveReceivedFilesToDisk = False
-        self._keepFilesInObject = True
-        return       
-        
-    def close(self):
-        """ Close the file interface.
-        
+        self._save_received_files_to_disk = False
+        self._keep_files_in_object = True
+        return
+
+    def close(self) -> None:
+        """
+        close the file interface
+
         The automatic file sending is disabled and the socket connection is closed.
         """
         self.disableAutomaticFileExchange()
         self.remoteConnection.disconnectFromTerm()
-        return            
-        
-    def enableAutomaticFileExchange(self,enable = True, fileExtensions = "*.ism*.isc*.isw*.iss"):
-        """ Turn on automatic file exchange.
-        
+        return
+
+    def enableAutomaticFileExchange(
+        self, enable: bool = True, fileExtensions: str = "*.ism*.isc*.isw*.iss"
+    ) -> str:
+        """
+        turn on automatic file exchange
+
         If automatic file exchange is enabled, the files configured with the fileExtensions variable are transferred automatically.
-        
+
         In order for the files to be automatically saved to disk, this must be configured with the :func:`~thales_remote.file_interface.ThalesFileInterface.enableSaveReceivedFilesToDisk` method.
         With the method :func:`~thales_remote.file_interface.ThalesFileInterface.enableKeepReceivedFilesInObject`
         can be set whether the files should still remain in the Python object, so that you can read
         the received files as an array with :func:`~thales_remote.file_interface.ThalesFileInterface.getReceivedFiles`.
-        The standard setting is that the files remain in the object.        
-        
+        The standard setting is that the files remain in the object.
+
+        TODO:
+            - The `fileExtensions` parameter looks flimsy; consider using sth. more robust
+
         :param enable: Enable automatic file exchange. Default = True.
         :param fileExtensions: File extensions that will be exchanged. You can see the default paramter.
             But you can also specify only one type of file or more.
         :type fileExtensions: string
         :returns: The response string from the device.
-        :rtype: string  
         """
-        if enable == True:
-            retval = self.remoteConnection.sendStringAndWaitForReplyString(f"3,{self._deviceName},4,ON,{fileExtensions}", message_type=128, answer_message_type=132)
+        if enable:
+            retval = self.remoteConnection.sendStringAndWaitForReplyString(
+                f"3,{self._device_name},4,ON,{fileExtensions}",
+                message_type=128,
+                answer_message_type=132,
+            )
             self._startWorker()
         else:
-            """
-            Sending the command that no more data should be sent.
-            Then wait 1 second until the Thales has possibly sent everything.
-            Then stopp the worker thread.
-            """
-            retval = self.remoteConnection.sendStringAndWaitForReplyString(f"3,{self._deviceName},4,OFF", message_type=128, answer_message_type=132)
+            # Sending the command that no more data should be sent.
+            # Then wait 1 second until the Thales has possibly sent everything.
+            # Then stopp the worker thread.
+            retval = self.remoteConnection.sendStringAndWaitForReplyString(
+                f"3,{self._device_name},4,OFF",
+                message_type=128,
+                answer_message_type=132,
+            )
             time.sleep(1)
-            self._stoppWorker()
+            self._stopWorker()
         return retval
-    
-    def appendFilesToSkip(self, file):
-        """ Set filenames to be filtered and not processed by Python.
-        
-        Files with these names are not saved to disk by Python and do not remain in the object.
-        
-        :param file: Filename or list with filenames to be filtered.
+
+    def appendFilesToSkip(self, file: Union[str, list[str]]):
         """
-        self._filesToSkip += file            
-        return
-        
-    def disableAutomaticFileExchange(self):
-        """ Turn off automatic file exchange.
-        
-        :returns: The response string from the device.
-        :rtype: string  
+        set filenames to be filtered and not processed by Python
+
+        Files with these names are not saved to disk by Python and do not remain in the object.
+
+        TODO:
+            - not sure if the `+=` operator works for both `str` and `list[str]`
+
+        :param file: filename or list with filenames to be filtered
+        """
+        if isinstance(file, list):
+            self._files_to_skip.extend(file)
+        else:
+            self._files_to_skip.append(file)
+
+    def disableAutomaticFileExchange(self) -> str:
+        """
+        turn off automatic file exchange
+
+        :returns: the response string from the device
         """
         return self.enableAutomaticFileExchange(False)
-    
-    def aquireFile(self,filename):
-        r""" Transfer a single file.
-        
+
+    def aquireFile(self, filename: str) -> Optional[dict[str, Union[str, bytearray]]]:
+        """
+        transfer a single file
+
         This command transfers a single from Term to Python.
         **This command can only be executed if automatic transfer is disabled.** If automatic transfer is enabled, None is returned.
         The parameter filename is used to specify the full path of the file, on the computer running
         the Thales software, to be transferred e.g. r"C:\\THALES\\temp\\test1\\myeis.ism".
-        
+
         The function returns the file as dictionary. The dictionary has the following keys:
-        
+
         * "name": Filename without path.
         * "path": Filename with path on the Thales computer.
         * "binary_data": Data as bytearray.
-        
+
         If the file does not exist, the key "binary_data" contains an empty byte array.
-        
+
         :param filename: Filename with path on the Thales computer.
         :type filename: string
         :returns: A dictionary with the file or None if this command is called when automatic file
             exchange is activated.
-        :rtype: dictionary, None
         """
-        file = None
-        if self._receiver_is_running == False:
-            self.remoteConnection.sendTelegram(f"3,{self._deviceName},1,{filename}", message_type=128)
-            file = self._receiveFile()
-        return file
-    
-    def setSavePath(self, path):
-        r""" Set the path where the files should be saved on the local computer.
-        
+        if self._receiver_is_running:
+            self.remoteConnection.sendTelegram(
+                f"3,{self._device_name},1,{filename}", message_type=128
+            )
+            return self._receiveFile()
+        else:
+            return None
+
+    def setSavePath(self, path: str) -> None:
+        """
+        set the path where the files should be saved on the local computer
+
         This command sets only the path. If the path does not exist, it will be created.
         The path must be accessible by Python, otherwise there are no restrictions on the path.
-        
+
         :param path: Path where the files should be saved. For example r"D:\\myLocalDirectory".
         :type path: string
         """
         self.pathToSave = path
-        os.makedirs(self.pathToSave, exist_ok = True)
+        os.makedirs(self.pathToSave, exist_ok=True)
         return
-    
-    def enableSaveReceivedFilesToDisk(self,enable = True, path = None):
-        r""" Enable the automatic saving of files to the hard disk.
-        
+
+    def enableSaveReceivedFilesToDisk(
+        self, enable: bool = True, path: Optional[str] = None
+    ) -> None:
+        """
+        enable the automatic saving of files to the hard disk
+
         This command configures that the files are automatically saved by Python.
         With this command the path can be passed with the optional parameter path.
         The path must be accessible by Python, otherwise there are no restrictions on the path.
         Default path is the current working directory of Python.
-        
+
         :param enable: Enable automatic file saving to the hard disk. Default = True.
         :param path: Optional path where the files should be saved. For example r"D:\\myLocalDirectory".
         :type path: string
         """
         if path is not None:
             self.setSavePath(path)
-        self._saveReceivedFilesToDisk = enable
-        return
-        
-    def disableSaveReceivedFilesToDisk(self):
-        """ Disable the automatic saving of files to the hard disk.
+        self._save_received_files_to_disk = enable
+
+    def disableSaveReceivedFilesToDisk(self) -> None:
+        """
+        disable the automatic saving of files to the hard disk
         """
         return self.enableSaveReceivedFilesToDisk(False)
-    
-    def enableKeepReceivedFilesInObject(self,enable = True):
-        """ Enable that the files remain in the Python object.
-        
+
+    def enableKeepReceivedFilesInObject(self, enable: bool = True):
+        """Enable that the files remain in the Python object.
+
         If you perform many measurements, the Python object would grow larger and larger due to the
         number of files, so you can disable that the files are stored in the object as an array.
         By default, the files remain in the object.
-        
+
         :param enable: True = Allow the files to remain in the object.
         """
-        self._keepFilesInObject = enable
+        self._keep_files_in_object = enable
         return
-    
-    def disableKeepReceivedFilesInObject(self):
-        """ Disable that the files remain in the Python object.
+
+    def disableKeepReceivedFilesInObject(self) -> None:
+        """
+        disable that the files remain in the Python object
         """
         return self.enableKeepReceivedFilesInObject(False)
-    
-    def getReceivedFiles(self):
-        """ Read all files from the Python object.
-        
+
+    def getReceivedFiles(self) -> list[dict[str, Union[str, bytearray]]]:
+        """
+        read all files from the Python object
+
         This function returns an array. Each element in the array is a dictionary as described in
         function :func:`~thales_remote.file_interface.ThalesFileInterface.aquireFile`.
-        
+
         :returns: Array with the files from the Python object.
-        :rtype: array 
         """
         return self.receivedFiles
-    
-    def getLatestReceivedFile(self):
-        """ Read the latest files from the Python object.    
-        
-        :returns: The latest file from the Python object.
-        :rtype: array 
+
+    def getLatestReceivedFile(self) -> dict[str, Union[str, bytearray]]:
         """
-        return  self.receivedFiles[-1]
-    
-    def deleteReceivedFiles(self):
-        """ Delete all files from the Python object.
+        read the latest files from the Python object
+
+        :returns: latest file from the Python object
+        """
+        return self.receivedFiles[-1]
+
+    def deleteReceivedFiles(self) -> None:
+        """
+        delete all files from the Python object
         """
         self.receivedFiles = []
         return
-        
-    """
-    The following methods should not be called by the user.
-    They are marked with the prefix '_' after the Python convention for proteced.
-    """
-    
-    def _saveReceivedFile(self, fileToWrite):
-        """ Saves the passed file to disk.
+
+    # The following methods should not be called by the user.
+    # They are marked with the prefix '_' after the Python convention for proteced.
+
+    def _saveReceivedFile(self, fileToWrite: str) -> None:
         """
-        if self._saveReceivedFilesToDisk == True:
-            fileNameWithPath = os.path.join(self.pathToSave,fileToWrite["name"])
-            
-            file = open(fileNameWithPath,"wb")
-            file.write(fileToWrite["binary_data"])
-            file.close()
+        saves the passed file to disk ONLY IF self._save_received_files_to_disk is enabled
+
+        TODO:
+            - if not self._save_received_files_to_disk, then this method seems to fail silently
+        """
+        if self._save_received_files_to_disk:
+            fileNameWithPath = os.path.join(self.pathToSave, fileToWrite["name"])
+
+            with open(fileNameWithPath, "wb") as file:
+                file.write(fileToWrite["binary_data"])
+                file.close()
         return
-    
-    def _receiveFile(self, timeout = None):
-        """ Receive one file with optional timeout.
+
+    def _receiveFile(
+        self, timeout: Optional[float] = None
+    ) -> dict[str, Union[str, bytearray]]:
         """
-        retval = None
+        receive one file with optional timeout
+
+        TODO:
+            - do not return a dict but a struct; this will prevent bugs in the future
+
+        :returns: a dict with these key-value-pairs:
+            - "name": file name as `str`
+            - "path": file path as `str`
+            - "binary_data": binary data as `bytearray`
+        """
+
         try:
-            filePath = self.remoteConnection.waitForStringTelegram(130,timeout = timeout)
+            filePath: str = self.remoteConnection.waitForStringTelegram(
+                130, timeout=timeout
+            )
         except Empty:
-            return retval
-        
+            return None
+
         fileLength = int(self.remoteConnection.waitForStringTelegram(129))
         bytesToReceive = fileLength
-        
+
         fileData = bytearray()
         while bytesToReceive > 0:
             receivedBytes = self.remoteConnection.waitForBinaryTelegram(131)
             fileData += receivedBytes
             bytesToReceive -= len(receivedBytes)
-        
-        retval = dict()
-        
-        fileSplit = filePath.split("\\")
-        fileName = fileSplit[-1]
-        
-        retval["name"] = fileName
-        retval["path"] = filePath
-        retval["binary_data"] = fileData
-        return retval
-    
-    def _startWorker(self):
-        """ Starts the thread handling the asyncronously incoming data.
+
+        file_split = filePath.split("\\")
+        file_name = file_split[-1]
+
+        return {"name": file_name, "path": filePath, "binary_data": fileData}
+
+    def _startWorker(self) -> None:
         """
-        if self._receiver_is_running == False:
+        starts the thread handling the asyncronously incoming data
+        """
+        if not self._receiver_is_running:
             self._receiver_is_running = True
             self.receivingWorker = threading.Thread(target=self._fileReceiverJob)
             self.receivingWorker.start()
         return
-    
-    def _stoppWorker(self):
-        """ Stops the thread handling the incoming data gracefully.
+
+    def _stopWorker(self) -> None:
         """
-        if self._receiver_is_running == True:
+        stops the thread handling the incoming data gracefully
+        """
+        if self._receiver_is_running:
             self._receiver_is_running = False
             self.receivingWorker.join()
         return
-            
+
     def _fileReceiverJob(self):
-        """ The method running in a separate thread, this method runs in a separate thread and manages the received files.
         """
-        while self._receiver_is_running == True:
+        method running in a separate thread; manages the received files
+        """
+        while self._receiver_is_running:
             try:
                 file = self._receiveFile(1)
                 if file is not None:
-                    if file["name"] not in self._filesToSkip:
-                        if self._keepFilesInObject == True:
+                    if file["name"] not in self._files_to_skip:
+                        if self._keep_files_in_object:
                             self.receivedFiles.append(file)
-                        
-                        if self._saveReceivedFilesToDisk == True:
+
+                        if self._save_received_files_to_disk:
                             self._saveReceivedFile(file)
             except:
                 self._receiver_is_running = False
         return
-    

--- a/thales_remote/script_wrapper.py
+++ b/thales_remote/script_wrapper.py
@@ -23,440 +23,462 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTIO
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
 THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
- 
+
 from enum import Enum
-from thales_remote.error import ThalesRemoteError
 import re
 import shutil
 import os
- 
- 
+from typing import Optional, Union, Any
+
+from .error import ThalesRemoteError
+from .connection import ThalesRemoteConnection
+
+
 class PotentiostatMode(Enum):
     """
-    Working modes for the potentiostat.
+    working modes for the potentiostat
     """
+
     POTMODE_POTENTIOSTATIC = 1
     POTMODE_GALVANOSTATIC = 2
     POTMODE_PSEUDOGALVANOSTATIC = 3
- 
- 
+
+
 class ThalesRemoteScriptWrapper(object):
     """
     Wrapper that uses the ThalesRemoteConnection class.
     The commands are explained in the `Remote2-Manual <https://doc.zahner.de/manuals/remote2.pdf>`_.
     In the document you can also find a table with error numbers which are returned.
-    
+
     :param remoteConnection: The connection object to the Thales software.
     :type remoteConnection: :class:`~thales_remote.connection.ThalesRemoteConnection`
     """
-    undefindedStandardErrorString = ""
- 
-    def __init__(self, remoteConnection):
-        self.remoteConnection = remoteConnection
-     
-    def getCurrent(self):
-        """ Read the measured current from the device.
-        
-        :returns: The current value.
-        :rtype: float
+
+    undefindedStandardErrorString: str = ""
+    _remote_connection: ThalesRemoteConnection
+
+    def __init__(self, remoteConnection: ThalesRemoteConnection):
+        self._remote_connection = remoteConnection
+
+    def getCurrent(self) -> float:
         """
-        return self._requestValueAndParseUsingRegexp("CURRENT", "current=\s*(.*?)A?[\r\n]{0,2}$")
-     
-    def getPotential(self):
-        """ Read the measured potential from the device.
-        
-        :returns: The potential value.
-        :rtype: float
+        read the measured current from the device
+
+        :returns: the measured current value
         """
-        return self._requestValueAndParseUsingRegexp("POTENTIAL", "potential=\s*(.*?)V?[\r\n]{0,2}$")
-     
-    def setCurrent(self, current):
-        """ Set the output current.
-        
-        :param current: The output current to set.
-        :returns: The response string from the device.
-        :rtype: string
+        return self._requestValueAndParseUsingRegexp(
+            "CURRENT", "current=\s*(.*?)A?[\r\n]{0,2}$"
+        )
+
+    def getPotential(self) -> float:
+        """
+        fead the measured potential from the device
+
+        :returns: the measured potential value
+        """
+        return self._requestValueAndParseUsingRegexp(
+            "POTENTIAL", "potential=\s*(.*?)V?[\r\n]{0,2}$"
+        )
+
+    def setCurrent(self, current: float) -> str:
+        """
+        set the output current
+
+        :param current: the output current to set
+        :returns: response string from the device
         """
         return self.setValue("Cset", current)
-     
-    def setPotential(self, potential):
-        """ Set the output potential.
-         
-        :param potential: The output potential to set.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setPotential(self, potential: float) -> str:
         """
-        return self.setValue("Pset", potential)    
-     
-    def setVoltage(self, potential):
-        """ Set the output potential.
-         
-        :param potential: The output potential to set.
-        :returns: The response string from the device.
-        :rtype: string
+        set the output potential
+
+        :param potential: the output potential to set
+        :returns: response string from the device
+        """
+        return self.setValue("Pset", potential)
+
+    def setVoltage(self, potential) -> str:
+        """
+        set the output potential
+
+        :param potential: the output potential to set
+        :returns: response string from the device
         """
         return self.setPotential(potential)
-     
-    def setMaximumShunt(self, shunt):
-        """ Set the maximum shunt for measurement.
-         
+
+    def setMaximumShunt(self, shunt: int) -> str:
+        """
+        set the maximum shunt index for measurement
+
         Set the maximum shunt index for impedance measurements.
-         
-        :param shunt: The number of the shunt.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param shunt: the number of the shunt
+        :returns: response string from the device
         """
         return self.setValue("Rmax", shunt)
-     
-    def setMinimumShunt(self, shunt):
-        """ Set the minimum shunt for measurement.
-         
+
+    def setMinimumShunt(self, shunt) -> str:
+        """
+        set the minimum shunt for measurement
+
         Set the minimum shunt index for impedance measurements.
-         
-        :param shunt: The number of the shunt.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param shunt: index of the shunt to set
+        :returns: response string from the device
         """
         return self.setValue("Rmin", shunt)
-     
-    def setShuntIndex(self, shunt):
-        """ Set the shunt for measurement.
-         
+
+    def setShuntIndex(self, shunt: int) -> None:
+        """
+        set the shunt index for measurement
+
         Fixes the shunt to the passed index.
-         
+
+        TODO:
+            - handle errors / response strings
+
         :param shunt: The number of the shunt.
-        :returns: The response string from the device.
-        :rtype: string
+        :returns: reponse string from the device
         """
         self.setMinimumShunt(shunt)
         self.setMaximumShunt(shunt)
         return
-         
-    def setVoltageRangeIndex(self, vrange):
-        """ Set the voltage range for measurement.
-        
-        If a Zennium, Zennium E, Zennium E4 or a device from the IM6 series is used, the set index must match the U-buffer. If the U-buffer does not match the set value, the measurement is wrong.
-        The Zennium pro, Zennium X and Zennium XC series automatically change the range.
-         
-        :param vrange: The number of the voltage range.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setVoltageRangeIndex(self, vrange: int) -> str:
+        """
+        set the voltage range for measurement
+
+        If a Zennium, Zennium E, Zennium E4 or a device from the IM6 series is
+        used, the set index must match the U-buffer. If the U-buffer does not
+        match the set value, the measurement is wrong.
+        The Zennium pro, Zennium X and Zennium XC series automatically change
+        the range.
+
+        :param vrange: index of the voltage range
+        :returns: response string from the device
         """
         return self.setValue("Potrange", vrange)
-         
-    def selectPotentiostat(self, device):
-        """ Set the device for output.
-        
-        Device which is to be selected, on which the settings are output.
-        First, the device must be selected.
-        Only then can devices other than the internal main potentiostat be configured.
-        
+
+    def selectPotentiostat(self, device: int) -> str:
+        """
+        select device onto which all subsequent calls to set* methods are forwarded
+
+        First, the device must be selected. Only then can devices other than
+        the internal main potentiostat be configured.
+
         :param device: Number of the device. 0 = Main. 1 = EPC channel 1 and so on.
-        :returns: The response string from the device.
-        :rtype: string
+        :returns: reponse string from the device
         """
         return self.setValue("DEV%", device)
-    
-    def switchToSCPIControl(self):
-        """ Change away from operation as EPC device to SCPI operation.
-        
+
+    def switchToSCPIControl(self) -> str:
+        """
+        change away from operation as EPC device to SCPI operation
+
         This command works only with external potentiostats of the latest generation PP212, PP222, PP242 and XPOT2.
         After this command they are no longer accessible with the EPC interface.
         Then you can connect to the potentiostat with USB via the Comports.
         The change back to EPC operation is also done explicitly from the USB side.
-        
-        :returns: The response string from the device.
-        :rtype: string
+
+        :returns: response string from the device
         """
         return self.executeRemoteCommand("SETUSB")
-     
-    def getSerialNumber(self):
-        """ Get the serial number of the active device.
-        
-        Active device ist the device selected with :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.selectPotentiostat`.
-        
-        :returns: The device serial number.
-        :rtype: string
+
+    def getSerialNumber(self) -> str:
+        """
+        get the serial number of the active device
+
+        Active device ist the device selected with
+        :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.selectPotentiostat`.
+
+        :returns: the device serial number
         """
         reply = self.executeRemoteCommand("ALLNUM")
         match = re.search("(.*);(.*);([a-zA-Z]*)", reply)
         return match.group(2)
-     
-    def getDeviceInformation(self):
-        """ Get the name and serial number of the active device.
-         
-        :returns: Returns a tuple with the information about the selected potentiostat. (Name, Serialnumber).
+
+    def getDeviceInformation(self) -> tuple[str, str]:
+        """
+        get the name and serial number of the active device
+
+        :returns: tuple with the information about the selected potentiostat. (Name, Serialnumber).
         """
         reply = self.executeRemoteCommand("DEVINF")
         match = re.search("(.*);(.*);(.*);([0-9]*)", reply)
         return match.group(3), match.group(4)
-    
-    def getSetup(self):
+
+    def getSetup(self) -> str:
+        """
+        TODO:
+            - documentation
+        """
         return self.executeRemoteCommand("SENDSETUP")
-     
-    def getDeviceName(self):
-        """ Get the name of the active device.
-         
-        :returns: The device name.
-        :rtype: string
+
+    def getDeviceName(self) -> str:
+        """
+        get the name of the active device
+
+        :returns: the device name
         """
         reply = self.executeRemoteCommand("ALLNUM")
         match = re.search("(.*);(.*);([a-zA-Z]*)", reply)
         return match.group(3)
-    
-    def calibrateOffsets(self):
-        """ Perform offset calibration on the device.
-        
+
+    def calibrateOffsets(self) -> str:
+        """
+        perform offset calibration on the device
+
         When the instrument has warmed up for about 30 minutes,
         this command can be used to perform the offset calibration again.
-        
-        :returns: The response string from the device.
-        :rtype: string
+
+        :returns: response string from the device
         """
         return self.executeRemoteCommand("CALOFFSETS")
-     
-    def enablePotentiostat(self, enabled=True):
-        """ Switch the potentiostat on or off.
-         
-        :param enabled: Switches the potentiostat on if true and off if false.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def enablePotentiostat(self, enabled: bool = True) -> str:
+        """
+        switch the potentiostat on or off
+
+        :param enabled: Switches the potentiostat on if True and off otherwise
+        :returns: response string from the device
         """
         if enabled:
             reply = self.executeRemoteCommand("Pot=-1")
         else:
             reply = self.executeRemoteCommand("Pot=0")
         return reply
-             
-    def disablePotentiostat(self):
-        """ Switch the potentiostat off.
-         
-        :returns: The response string from the device.
-        :rtype: string
+
+    def disablePotentiostat(self) -> str:
+        """
+        switch the potentiostat off
+
+        :returns: response string from the device
         """
         return self.enablePotentiostat(False)
-     
-    def setPotentiostatMode(self, potentiostatMode: PotentiostatMode):
-        """ Set the coupling of the potentiostat.
-         
+
+    def setPotentiostatMode(self, potentiostatMode: PotentiostatMode) -> str:
+        """
+        set the coupling of the potentiostat
+
         This can be PotentiostatMode.POTMODE_POTENTIOSTATIC or PotentiostatMode.POTMODE_GALVANOSTATIC or
         PotentiostatMode.POTMODE_PSEUDOGALVANOSTATIC.
-        
+
         :param potentiostatMode: The coupling of the potentiostat
         :type potentiostatMode: :class:`~thales_remote.script_wrapper.PotentiostatMode`
-        :returns: The response string from the device.
-        :rtype: string
+        :returns: response string from the device
         """
-        if potentiostatMode == PotentiostatMode.POTMODE_POTENTIOSTATIC:
-            command = "Gal=0:GAL=0"
-        elif potentiostatMode == PotentiostatMode.POTMODE_GALVANOSTATIC:
-            command = "Gal=-1:GAL=1"
-        elif potentiostatMode == PotentiostatMode.POTMODE_PSEUDOGALVANOSTATIC:
-            command = "Gal=0:GAL=-1"
-        else:
-            return ""
-        return self.executeRemoteCommand(command)
-         
-    def enableRuleFileUsage(self, enable=True):
-        """ Enable the usage of a rule file.
-        
+        command_strings = {
+            PotentiostatMode.POTMODE_POTENTIOSTATIC: "Gal=0:GAL=0",
+            PotentiostatMode.POTMODE_GALVANOSTATIC: "Gal=-1:GAL=1",
+            PotentiostatMode.POTMODE_PSEUDOGALVANOSTATIC: "Gal=0:GAL=-1",
+        }
+        if not potentiostatMode in command_strings:
+            raise ValueError("invalid potentiostat mode: " + str(potentiostatMode))
+        return self.executeRemoteCommand(command_strings.get(potentiostatMode))
+
+    def enableRuleFileUsage(self, enable: bool = True) -> str:
+        """
+        enable the usage of a rule file
+
         If the usage of the rule file is activated all the parameters required
         for the EIS, CV, and/or IE are taken from the rule file.
         The exact usage can be found in the remote manual.
-        
+
         :param potentiostatMode: Enable the state of rule file usage.
-        :returns: The response string from the device.
-        :rtype: string
+        :returns: response string from the device
         """
-        if enable == True:
-            enable = 1
-        else:
-            enable = 0
-        return self.setValue("UseRuleFile", enable)
-     
-    def disableRuleFileUsage(self):
-        """ Disable the usage of a rule file.
-         
-        :returns: The response string from the device.
-        :rtype: string
+        return self.setValue("UseRuleFile", 1 if enable else 0)
+
+    def disableRuleFileUsage(self) -> str:
+        """
+        disable the usage of a rule file
+
+        :returns: reponse string from the device
         """
         return self.enableRuleFileUsage(False)
-     
-    def setupPAD4(self, card, channel, state):
-        """ Setting a channel of a PAD4 card for an EIS measurement.
-                
-        :param card: The number of the card starting at 1 and up to 4.
-        :type card: int
-        :param channel: The channel of the card starting at 1 and up to 4.
-        :type channel: int
-        :param state: If state = 1 the channel is switched on else switched off.
-        :type state: int
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setupPAD4(self, card: int, channel: int, state: Union[int, bool]) -> str:
         """
-        command = "PAD4=" + str(card) + ";"
-        command = command + str(channel) + ";"
-        if state == 1:
-            command = command + "1"
-        else:
-            command = command + "0"
-        reply = self.executeRemoteCommand(command)
-        
-        if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+        Setting a channel of a PAD4 card for an EIS measurement
+
+        :param card: index of the card starting at 1 and up to 4
+        :param channel: index of the card starting at 1 and up to 4
+        :param state: If `1` or `True` the channel is switched on else switched off
+        :returns: reponse string from the device
+        """
+        if isinstance(state, int):
+            state = state == 1
+        reply = self.executeRemoteCommand(
+            "PAD4=" + str(card) + ";" + ("1" if state else "0")
+        )
+
+        if "ERROR" in reply:
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-     
-    def enablePAD4(self, state=True):
-        """ Switching on the set PAD4 channels.
-        
+
+    def enablePAD4(self, state: bool = True) -> str:
+        """
+        switch on the set PAD4 channels
+
         The files of the measurement results with PAD4 are numbered consecutively.
         The lowest number is the main channel of the potentiostat.
-        
+
         :param state: If state = True PAD4 channels are enabled.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
-        if state == True:
-            state = 1
-        else:
-            state = 0
-        return self.setValue("PAD4ENA", state)
-     
-    def disablePAD4(self):
-        """ Switching off the set PAD4 channels.
-        
-        :returns: The response string from the device.
-        :rtype: string
+        return self.setValue("PAD4ENA", 1 if state else 0)
+
+    def disablePAD4(self) -> str:
+        """
+        switch off the set PAD4 channels
+
+        :returns: reponse string from the device
         """
         return self.enablePAD4(False)
-     
-    def readPAD4Setup(self):
-        """ Read the set parameters.
-        
+
+    def readPAD4Setup(self) -> str:
+        """
+        read the currently set parameters
+
         Reading the set PAD4 configuration.
-        
-        :returns: The response string from the device.
-        :rtype: string
+
+        TODO:
+            - document return value
+
+        :returns: reponse string from the device
         """
         reply = self.executeRemoteCommand("SENDPAD4SETUP")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-         
-    """
-    Section with settings for single impedance and EIS measurements.
-    """
 
-    def setFrequency(self, frequency):
-        """ Set the output frequency for single frequency impedance.
-        
-        :param frequency: The output frequency for Impedance measurement to set.
-        :returns: The response string from the device.
-        :rtype: string
+    # Section with settings for single impedance and EIS measurements.
+
+    def setFrequency(self, frequency: float) -> str:
+        """Set the output frequency for single frequency impedance.
+
+        :param frequency: the output frequency for Impedance measurement to set
+        :returns: reponse string from the device
         """
-        return self.setValue("Frq", frequency)  
-     
-    def setAmplitude(self, amplitude):
-        """ Set the output amplitude
-        
-        :param amplitude: The output amplitude for Impedance measurement to set in Volt or Ampere.
-        :returns: The response string from the device.
-        :rtype: string
+        return self.setValue("Frq", frequency)
+
+    def setAmplitude(self, amplitude: float) -> str:
         """
-        return self.setValue("Ampl", amplitude * 1e3)  
-     
-    def setNumberOfPeriods(self, number_of_periods):
-        """ Set the number of periods to average for one impedance measurement.
-        
-        :param number_of_periods: The number of periods / waves to average.
-        :returns: The response string from the device.
-        :rtype: string
+        set the output amplitude
+
+        :param amplitude: the output amplitude for Impedance measurement to set in Volt or Ampere
+        :returns: reponse string from the device
         """
-        number_of_periods = round(number_of_periods)
+        return self.setValue("Ampl", amplitude * 1e3)
+
+    def setNumberOfPeriods(self, number_of_periods: Union[int, float]):
+        """
+        set the number of periods to average for one impedance measurement
+
+        :param number_of_periods: the number of periods / waves to average
+        :returns: reponse string from the device
+        """
+        if isinstance(number_of_periods, float):
+            number_of_periods = round(number_of_periods)
         if number_of_periods > 100:
             number_of_periods = 100
-         
+
         if number_of_periods < 1:
             number_of_periods = 1
-         
+
         return self.setValue("Nw", number_of_periods)
-     
-    def setUpperFrequencyLimit(self, frequency):
-        """ Set the upper frequency limit for EIS measurements.
-        
-        :param frequency: The upper frequency limit.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setUpperFrequencyLimit(self, frequency: float) -> str:
+        """
+        set the upper frequency limit for EIS measurements
+
+        :param frequency: the upper frequency limit to set
+        :returns: reponse string from the device
         """
         return self.setValue("Fmax", frequency)
-     
-    def setLowerFrequencyLimit(self, frequency):
-        """ Set the lower frequency limit for EIS measurements.
-        
-        :param frequency: The lower frequency limit.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setLowerFrequencyLimit(self, frequency: float) -> str:
+        """
+        set the lower frequency limit for EIS measurements
+
+        :param frequency: the lower frequency limit to set
+        :returns: reponse string from the device
         """
         return self.setValue("Fmin", frequency)
-     
-    def setStartFrequency(self, frequency):
-        """ Set the start frequency for EIS measurements.
-        
-        :param frequency: The start frequency.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setStartFrequency(self, frequency: float) -> str:
+        """
+        set the start frequency for EIS measurements
+
+        :param frequency: the start frequency to set
+        :returns: reponse string from the device
         """
         return self.setValue("Fstart", frequency)
-     
-    def setUpperStepsPerDecade(self, steps):
-        """ Set the number of steps per decade in frequency range above 66 Hz for EIS measurements.
-                
-        :param steps: The number of steps per decade.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setUpperStepsPerDecade(self, steps: int) -> str:
+        """
+        set the number of steps per decade in frequency range above 66 Hz for EIS measurements
+
+        :param steps: the number of steps per decade to set
+        :returns: reponse string from the device
         """
         return self.setValue("dfm", steps)
-     
-    def setLowerStepsPerDecade(self, steps):
-        """ Set the number of steps per decade in frequency range below 66 Hz for EIS measurements.
-        
-        :param steps: The number of steps per decade.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setLowerStepsPerDecade(self, steps: int) -> str:
+        """
+        set the number of steps per decade in frequency range below 66 Hz for EIS measurements
+
+        :param steps: the number of steps per decade to set
+        :returns: reponse string from the device
         """
         return self.setValue("dfl", steps)
-     
-    def setUpperNumberOfPeriods(self, periods):
-        """ Set the number of periods to measure in frequency range above 66 Hz for EIS measurements.
-        Must be greater than :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setLowerNumberOfPeriods`.
-        
-        :param periods: The number of periods.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setUpperNumberOfPeriods(self, periods: int) -> str:
+        """
+        set the number of periods to measure in frequency range above 66 Hz for EIS measurements
+
+        Note:
+            value must be greater than the one set with
+            :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setLowerNumberOfPeriods`
+
+        :param periods: the number of periods to set
+        :returns: reponse string from the device
         """
         return self.setValue("Nws", periods)
-     
-    def setLowerNumberOfPeriods(self, periods):
-        """ Set the number of periods to measure  in frequency range below 66 Hz for EIS measurements.
-        Must be smaller than :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setUpperNumberOfPeriods`.
-        
-        :param periods: The number of periods.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setLowerNumberOfPeriods(self, periods: int) -> str:
+        """
+        set the number of periods to measure  in frequency range below 66 Hz for EIS measurements
+
+        Note:
+            Value mustbe smaller than the one set with
+            :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setUpperNumberOfPeriods`.
+
+        :param periods: the number of periods to set
+        :returns: reponse string from the device
         """
         return self.setValue("Nwl", periods)
-     
-    def setScanStrategy(self, strategy):
-        """ Set the scan strategy for EIS measurements.
-        
+
+    def setScanStrategy(self, strategy: str) -> str:
+        """Set the scan strategy for EIS measurements.
+
         strategy = "single": single sine.
         strategy = "multi": multi sine.
         strategy = "table": frequency table.
-        
-        :param strategy: The scan for EIS measurements.
-        :type strategy: string
-        :returns: The response string from the device.
-        :rtype: string
+
+        TODO:
+            - change parameter `strategy` to an enum
+
+        :param strategy: the scan strategy to set for EIS measurements
+        :returns: reponse string from the device
         """
         if strategy == "multi":
             strategy = 1
@@ -465,33 +487,39 @@ class ThalesRemoteScriptWrapper(object):
         else:
             strategy = 0
         return self.setValue("ScanStrategy", strategy)
-     
-    def setScanDirection(self, direction):
-        """ Set the scan direction for EIS measurements.
-        
+
+    def setScanDirection(self, direction: str) -> str:
+        """Set the scan direction for EIS measurements.
+
         direction = "startToMax": Scan at first from start to maximum frequency.
         direction = "startToMin": Scan at first from start to lower frequency.
-        
+
         :param direction: The scan direction for EIS measurements.
         :type direction: string
-        :returns: The response string from the device.
-        :rtype: string  
+        :returns: reponse string from the device
+        :rtype: string
         """
         if direction == "startToMin":
             direction = 1
         else:
             direction = 0
         return self.setValue("ScanDirection", direction)
-     
-    def getImpedance(self, frequency=None, amplitude=None, number_of_periods=None):
-        """ Measure the impedance.
-        
+
+    def getImpedance(
+        self,
+        frequency: Optional[float] = None,
+        amplitude: Optional[float] = None,
+        number_of_periods: Optional[int] = None,
+    ) -> complex:
+        """
+        measure the impedance
+
         Measure the impedance with the parameters. If the parameters are omitted the last will be used.
-        
+
         \param [in] frequency the frequency to measure the impedance at.
         \param [in] amplitude the amplitude to measure the impedance with. In Volt if potentiostatic mode or Ampere for galvanostatic mode.
         \param [in] number_of_periods the number of periods / waves to average.
-        
+
         :param frequency: The frequency to measure the impedance at.
         :param amplitude: The amplitude to measure the impedance with. In Volt if potentiostatic mode or Ampere for galvanostatic mode.
         :param number_of_periods: The number of periods / waves to average.
@@ -500,31 +528,33 @@ class ThalesRemoteScriptWrapper(object):
         """
         if frequency != None:
             self.setFrequency(frequency)
-             
+
         if amplitude != None:
             self.setAmplitude(amplitude)
-             
+
         if number_of_periods != None:
             self.setNumberOfPeriods(number_of_periods)
-         
+
         reply = self.executeRemoteCommand("IMPEDANCE")
-         
+
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         match = re.search("impedance=\\s*(.*?),\\s*(.*?)$", reply)
         return complex(float(match.group(1)), float(match.group(2)))
-     
-    def setEISNaming(self, naming):
-        """ Set the EIS measurement naming rule.
-        
+
+    def setEISNaming(self, naming: str) -> str:
+        """
+        set the EIS measurement naming rule
+
         naming = "dateTime": extend the :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setEISOutputFileName` with date and time.
         naming = "counter": extend the :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setEISOutputFileName` with an sequential number.
         naming = "individual": the file is named like :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setEISOutputFileName`.
-        
-        :param naming: The EIS measurement naming rule.
-        :type naming: string
-        :returns: The response string from the device.
-        :rtype: string  
+
+        :param naming: the EIS measurement naming rule to set
+        :returns: reponse string from the device
         """
         if naming == "dateTime":
             naming = 0
@@ -533,270 +563,255 @@ class ThalesRemoteScriptWrapper(object):
         else:
             naming = 1
         return self.setValue("EIS_MOD", naming)
-     
-    def setEISCounter(self, number):
-        """ Set the current number of EIS measurement for filename.
-        
+
+    def setEISCounter(self, number: int) -> str:
+        """
+        set the current number of EIS measurement for filename
+
         Current number for the file name for EIS measurements which is used next and then incremented.
-        
-        :param number: The next measurement number.
-        :returns: The response string from the device.
+
+        :param number: the next measurement number to set
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("EIS_NUM", number)
-     
-    def setEISOutputPath(self, path):
-        """ Set the path where the EIS measurements should be stored.
-        
+
+    def setEISOutputPath(self, path: str) -> str:
+        """
+        set the path where the EIS measurements should be stored
+
         The results must be stored on the C hard disk.
         If an error occurs test an alternative path or c:\THALES\temp.
         The directory must exist.
-        
-        :param path: The path to the directory.
-        :type path: string
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param path: path to the directory
+        :returns: reponse string from the device
         """
         path = path.lower()  # c: has to be lower case
         return self.setValue("EIS_PATH", path)
-     
-    def setEISOutputFileName(self, name):
-        """ Set the basic EIS output filename.
-        
+
+    def setEISOutputFileName(self, name: str) -> str:
+        """
+        set the basic EIS output filename
+
         The basic name of the file, which is extended by a sequential number or the date and time.
         Only numbers, underscores and letters from a-Z may be used.
-        
+
         If the name is set to "individual", the file with the same name must not yet exist.
         Existing files are not overwritten.
-        
-        :param name: The basic name of the file.
-        :type name: string
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param name: basic name of the file
+        :returns: reponse string from the device
         """
         return self.setValue("EIS_ROOT", name)
-         
-    def measureEIS(self):
-        """ Measure EIS.
-        
+
+    def measureEIS(self) -> str:
+        """
+        take an EIS measurement
+
         For the measurement all parameters must be specified before.
-        
-        :returns: The response string from the device.
-        :rtype: string
+
+        :returns: reponse string from the device
         """
         reply = self.executeRemoteCommand("EIS")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-         
-    """
-    Section with settings for CV measurements.
-    """
- 
-    def setCVStartPotential(self, potential):
-        """ Set the start potential of a CV measurment.
-        
-        :param potential: The start potential.
-        :returns: The response string from the device.
-        :rtype: string  
+
+    # Section with settings for CV measurements.
+
+    def setCVStartPotential(self, potential: float) -> str:
+        """
+        set the start potential of a CV measurment
+
+        :param potential: the start potential to set
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Pstart", potential)
-     
-    def setCVUpperReversingPotential(self, potential):
-        """ Set the upper reversal potential of a CV measurement.
-        
-        :param potential: The upper reversal potential.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setCVUpperReversingPotential(self, potential: float) -> str:
+        """
+        set the upper reversal potential of a CV measurement
+
+        :param potential: the upper reversal potential to set
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Pupper", potential)
-     
-    def setCVLowerReversingPotential(self, potential):
-        """ Set the lower reversal potential of a CV measurement.
-        
-        :param potential: The lower reversal potential.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setCVLowerReversingPotential(self, potential: float) -> str:
+        """
+        set the lower reversal potential of a CV measurement
+
+        :param potential: the lower reversal potential to set
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Plower", potential)
-     
-    def setCVEndPotential(self, potential):
-        """ Set the end potential of a CV measurment.
-        
-        :param potential: The end potential.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setCVEndPotential(self, potential: float) -> str:
+        """
+        set the end potential of a CV measurment
+
+        :param potential: the end potential to set
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Pend", potential)
-     
-    def setCVStartHoldTime(self, time):
-        """ Setting the holding time at the start potential.
-         
+
+    def setCVStartHoldTime(self, time: float) -> str:
+        """
+        setting the holding time at the start potential
+
         The time must be given in seconds.
-        
-        :param time: The waiting time at start potential in s.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param time: the waiting time at start potential in s
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Tstart", time)
-     
-    def setCVEndHoldTime(self, time):
-        """ Setting the holding time at the end potential.
-         
+
+    def setCVEndHoldTime(self, time: float) -> str:
+        """
+        setting the holding time at the end potential
+
         The time must be given in seconds.
-        
-        :param time: The waiting time at end potential in s.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param time: the waiting time at end potential in s
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Tend", time)
-     
-    def setCVScanRate(self, scanRate):
-        """ Set the scan rate.
-         
+
+    def setCVScanRate(self, scanRate: float) -> str:
+        """
+        set the scan rate
+
         The scan rate must be specified in V/s.
-        
-        :param scanRate: The scan rate in V/s.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param scanRate: the scan rate to set in V/s
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Srate", scanRate)
-     
-    def setCVCycles(self, cycles):
-        """ Set the number of cycles.
-        
+
+    def setCVCycles(self, cycles: int) -> str:
+        """
+        set the number of cycles
+
         At least 0.5 cycles are necessary.
         The number of cycles must be a multiple of 0.5. 3.5 are also possible, for example.
-        
-        :param cycles: The number of CV cycles, at least 0.5.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param cycles: the number of CV cycles to set, at least 0.5.
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Periods", cycles)
-     
-    def setCVSamplesPerCycle(self, samples):
-        """ Set the number of measurements per CV cycle.
-        
-        :param samples: The number of measurments per cycle.
-        :returns: The response string from the device.
-        :rtype: string
+
+    def setCVSamplesPerCycle(self, samples: int) -> str:
+        """
+        set the number of measurements per CV cycle
+
+        :param samples: the number of measurments per cycle to set
+        :returns: reponse string from the device
         """
         return self.setValue("CV_PpPer", samples)
-     
-    def setCVMaximumCurrent(self, current):
-        """ Set the maximum current.
-        
+
+    def setCVMaximumCurrent(self, current: float) -> str:
+        """
+        set the maximum current
+
         The maximum positive current at which the measurement is interrupted.
-        
-        :param current: The maximum current for measurement in A.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param current: The maximum current for measurement in A at which the measurement is interrupted
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Ima", current)
-     
-    def setCVMinimumCurrent(self, current):
-        """ Set the minimum current.
-        
+
+    def setCVMinimumCurrent(self, current: float) -> str:
+        """
+        set the minimum current
+
         The maximum negative current at which the measurement is interrupted.
-        
+
         :param current: The minimum current for measurement in A.
-        :returns: The response string from the device.
-        :rtype: string
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Imi", current)
-     
-    def setCVOhmicDrop(self, ohmicdrop):
-        """ Set the ohmic drop for CV measurement.
-        
+
+    def setCVOhmicDrop(self, ohmicdrop: float) -> str:
+        """
+        Set the ohmic drop for CV measurement
+
         :param ohmicdrop: The ohmic drop for measurement.
-        :returns: The response string from the device.
-        :rtype: string
+        :returns: reponse string from the device
         """
         return self.setValue("CV_Odrop", ohmicdrop)
-     
-    def enableCVAutoRestartAtCurrentOverflow(self, state=True):
-        """ Automatically restart if current is exceeded.
-        
+
+    def enableCVAutoRestartAtCurrentOverflow(self, state: bool = True) -> str:
+        """Automatically restart if current is exceeded.
+
         A new measurement is automatically started with a different
         reverse potential at which the current limit is not exceeded.
-        
-        :param state: If state = True the auto restart is enabled.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param state: If state == True the auto restart is enabled.
+        :returns: reponse string from the device
         """
-        if state == True:
-            state = 1
-        else:
-            state = 0
-        return self.setValue("CV_AutoReStart", state)
-     
-    def disableCVAutoRestartAtCurrentOverflow(self):
-        """ Disable automatically restart if current is exceeded.
-        
-        :returns: The response string from the device.
-        :rtype: string
+        return self.setValue("CV_AutoReStart", 1 if state else 0)
+
+    def disableCVAutoRestartAtCurrentOverflow(self) -> str:
+        """
+        disable automatic restart if current is exceeded
+
+        :returns: reponse string from the device
         """
         return self.enableCVAutoRestartAtCurrentOverflow(False)
-     
-    def enableCVAutoRestartAtCurrentUnderflow(self, state=True):
-        """ Restart automatically if the current drops below the limit.
-        
+
+    def enableCVAutoRestartAtCurrentUnderflow(self, state: bool = True) -> str:
+        """Restart automatically if the current drops below the limit.
+
         A new measurement is automatically started with a smaller
         current range than that determined by the minimum and maximum current.
-        
+
         :param state: If state = True the auto restart is enabled.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
-        if state == True:
-            state = 1
-        else:
-            state = 0
-        return self.setValue("CV_AutoScale", state)
-     
-    def disableCVAutoRestartAtCurrentUnderflow(self):
-        """ Disable automatically restart if the current drops below the limit.
-        
-        :returns: The response string from the device.
-        :rtype: string
+        return self.setValue("CV_AutoScale", 1 if state else 0)
+
+    def disableCVAutoRestartAtCurrentUnderflow(self) -> str:
+        """
+        disable automatically restart if the current drops below the limit
+
+        :returns: reponse string from the device
         """
         return self.enableCVAutoRestartAtCurrentUnderflow(False)
-     
-    def enableCVAnalogFunctionGenerator(self, state=True):
-        """ Switch on the analog function generator (AFG).
-        
+
+    def enableCVAnalogFunctionGenerator(self, state: bool = True):
+        """
+        switch on the analog function generator (AFG)
+
         The analog function generator can only be used if it was purchased with the device.
         If the device has the AFG function, you will see a button in the CV software to activate this function.
-        
-        :param state: If state = True the AFG is used.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param state: If state == True the AFG is used.
+        :returns: reponse string from the device
         """
-        if state == True:
-            state = 1
-        else:
-            state = 0
-        return self.setValue("CV_AFGena", state)
-     
-    def disableCVAnalogFunctionGenerator(self):
-        """ Disable the analog function generator (AFG).
-         
-        :returns: The response string from the device.
-        :rtype: string
+        return self.setValue("CV_AFGena", 1 if state else 0)
+
+    def disableCVAnalogFunctionGenerator(self) -> str:
+        """
+        disable the analog function generator (AFG)
+
+        :returns: reponse string from the device
         """
         return self.enableCVAnalogFunctionGenerator(False)
-     
-    def setCVNaming(self, naming):
-        """ Set the CV measurement naming rule.
-        
+
+    def setCVNaming(self, naming: str) -> str:
+        """Set the CV measurement naming rule.
+
         naming = "dateTime": extend the :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setCVOutputFileName` with date and time.
         naming = "counter": extend the :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setCVOutputFileName` with an sequential number.
         naming = "individual": the file is named like :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setCVOutputFileName`.
-        
-        :param naming: The CV measurement naming rule.
-        :type naming: string
-        :returns: The response string from the device.
-        :rtype: string  
+
+        :param naming: CV measurement naming rule to set
+        :returns: reponse string from the device
         """
         if naming == "dateTime":
             naming = 0
@@ -805,136 +820,154 @@ class ThalesRemoteScriptWrapper(object):
         else:
             naming = 1
         return self.setValue("CV_MOD", naming)
-     
-    def setCVCounter(self, number):
-        """ Set the current number of CV measurement for filename.
-        
+
+    def setCVCounter(self, number: int) -> str:
+        """
+        set the current number of CV measurement for filename
+
         Current number for the file name for CV measurements which is used next and then incremented.
-        
-        :param number: The next measurement number
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param number: the next measurement number
+        :returns: reponse string from the device
         """
         return self.setValue("CV_NUM", number)
-     
-    def setCVOutputPath(self, path):
-        """ Set the path where the CV measurements should be stored.
-        
+
+    def setCVOutputPath(self, path: str) -> str:
+        """
+        set the path where the CV measurements should be stored.
+
         The results must be stored on the C hard disk.
         If an error occurs test an alternative path or c:\THALES\temp.
         The directory must exist.
-        
-        :param path: The path to the directory.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param path: path to the output directory
+        :returns: reponse string from the device
         """
         path = path.lower()  # c: has to be lower case
         return self.setValue("CV_PATH", path)
-     
-    def setCVOutputFileName(self, name):
-        """ Set the basic CV output filename.
-        
+
+    def setCVOutputFileName(self, name: str) -> str:
+        """
+        set the basic CV output filename
+
         The basic name of the file, which is extended by a sequential number or the date and time.
         Only numbers, underscores and letters from a-Z may be used.
-        
+
         If the name is set to "individual", the file with the same name must not yet exist.
         Existing files are not overwritten.
-        
-        :param name: The basic name of the file.
-        :returns: The response string from the device.
-        :rtype: string
+
+        :param name: basic name of the file to set
+        :returns: reponse string from the device
         """
         return self.setValue("CV_ROOT", name)
-     
-    def checkCVSetup(self):
-        """ Check the set parameters.
-        
+
+    def checkCVSetup(self) -> str:
+        """
+        check the set parameters
+
         With the error number the wrong parameter can be found.
         The error numbers are listed in the Remote2 manual.
-        
-        :returns: The response string from the device.
-        :rtype: string
+
+        TODO:
+            - document return value meaning
+
+        :returns: reponse string from the device
         """
         reply = self.executeRemoteCommand("CHECKCV")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-     
-    def readCVSetup(self):
-        """ Read the set parameters.
-        
+
+    def readCVSetup(self) -> str:
+        """
+        read the set parameters
+
         After checking with checkCVSetup() the parameters can be read back from the workstation.
-        
-        :returns: The response string from the device.
-        :rtype: string
+
+        TODO:
+            - document return value meaning
+
+        :returns: reponse string from the device
         """
         reply = self.executeRemoteCommand("SENDCVSETUP")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-     
-    def measureCV(self):
-        """ Measure CV.
-         
-        Before measurement, all parameters must be checked with :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.checkCVSetup`.
-        
-        :returns: The response string from the device.
-        :rtype: string
+
+    def measureCV(self) -> str:
+        """
+        take a CV (cyclic voltammetry) measurement
+
+        Note:
+            Before starting the measurement, all parameters must be checked with
+            :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.checkCVSetup`.
+
+        TODO:
+            - document return value meaning
+
+        :returns: reponse string from the device
         """
         reply = self.executeRemoteCommand("CV")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-         
-    """
-    Section with settings for IE measurements.
-    Additional informations can be found in the IE manual.
-    """
-    
+
+    # Section with settings for IE measurements.
+    # Additional informations can be found in the IE manual.
+
     def setIEFirstEdgePotential(self, potential):
-        """ Set the first edge potential.
-        
+        """Set the first edge potential.
+
         :param potential: The potential of the first edge in V.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
-        """    
+        """
         return self.setValue("IE_EckPot1", potential)
-    
+
     def setIESecondEdgePotential(self, potential):
-        """ Set the second edge potential.
-        
+        """Set the second edge potential.
+
         :param potential: The potential of the second edge in V.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
-        """    
+        """
         return self.setValue("IE_EckPot2", potential)
-    
+
     def setIEThirdEdgePotential(self, potential):
-        """ Set the third edge potential.
-        
+        """Set the third edge potential.
+
         :param potential: The potential of the third edge in V.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
-        """    
+        """
         return self.setValue("IE_EckPot3", potential)
-    
+
     def setIEFourthEdgePotential(self, potential):
-        """ Set the fourth edge potential.
-        
+        """Set the fourth edge potential.
+
         :param potential: The potential of the fourth edge in V.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
-        """    
+        """
         return self.setValue("IE_EckPot4", potential)
-    
+
     def setIEFirstEdgePotentialRelation(self, relation):
-        """ Set the relation of the first edge potential.
-        
+        """Set the relation of the first edge potential.
+
         relation = "absolute": Absolute relation of the potential.
         relation = "relative": Relative relation of the potential.
-        
+
         :param relation: The relation of the edge potential absolute or relative.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if relation == "relative":
@@ -942,15 +975,15 @@ class ThalesRemoteScriptWrapper(object):
         else:
             relation = 0
         return self.setValue("IE_EckPot1rel", relation)
-    
+
     def setIESecondEdgePotentialRelation(self, relation):
-        """ Set the relation of the second edge potential.
-        
+        """Set the relation of the second edge potential.
+
         relation = "absolute": Absolute relation of the potential.
         relation = "relative": Relative relation of the potential.
-        
+
         :param relation: The relation of the edge potential absolute or relative.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if relation == "relative":
@@ -958,15 +991,15 @@ class ThalesRemoteScriptWrapper(object):
         else:
             relation = 0
         return self.setValue("IE_EckPot2rel", relation)
-    
+
     def setIEThirdEdgePotentialRelation(self, relation):
-        """ Set the relation of the third edge potential.
-        
+        """Set the relation of the third edge potential.
+
         relation = "absolute": Absolute relation of the potential.
         relation = "relative": Relative relation of the potential.
-        
+
         :param relation: The relation of the edge potential absolute or relative.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if relation == "relative":
@@ -974,15 +1007,15 @@ class ThalesRemoteScriptWrapper(object):
         else:
             relation = 0
         return self.setValue("IE_EckPot3rel", relation)
-    
+
     def setIEFourthEdgePotentialRelation(self, relation):
-        """ Set the relation of the fourth edge potential.
-        
+        """Set the relation of the fourth edge potential.
+
         relation = "absolute": Absolute relation of the potential.
         relation = "relative": Relative relation of the potential.
-        
+
         :param relation: The relation of the edge potential absolute or relative.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if relation == "relative":
@@ -990,142 +1023,142 @@ class ThalesRemoteScriptWrapper(object):
         else:
             relation = 0
         return self.setValue("IE_EckPot4rel", relation)
-     
+
     def setIEPotentialResolution(self, resolution):
-        """ Set the potential resolution.
-        
+        """Set the potential resolution.
+
         The potential step size for IE measurements in V.
-        
+
         :param relation: The resolution for the measurement in V.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_Resolution", resolution)
-     
+
     def setIEMinimumWaitingTime(self, time):
-        """ Set the minimum waiting time.
-        
+        """Set the minimum waiting time.
+
         The minimum waiting time on each step of the IE measurement.
         This time is at least waited, even if the tolerance abort criteria are met.
-        
+
         :param time: The waiting time in seconds.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_WZmin", time)
-     
+
     def setIEMaximumWaitingTime(self, time):
-        """ Set the maximum waiting time.
-        
+        """Set the maximum waiting time.
+
         The maximum waiting time on each step of the IE measurement.
         After this time the measurement is stopped at this potential
         and continued with the next potential even if the tolerances are not reached.
-        
+
         :param time: The waiting time in seconds.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_WZmax", time)
-     
+
     def setIERelativeTolerance(self, tolerance):
-        """ Set the relative tolerance criteria.
-        
+        """Set the relative tolerance criteria.
+
         This parameter is only used in sweep mode steady state.
         The relative tolerance to wait in percent.
         The explanation can be found in the IE manual.
-        
+
         :param tolerance: The tolerance to wait until break, 0.01 = 1%.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_Torel", tolerance)
-     
+
     def setIEAbsoluteTolerance(self, tolerance):
-        """ Set the absolute tolerance criteria.
-         
+        """Set the absolute tolerance criteria.
+
         This parameter is only used in sweep mode steady state.
         The absolute tolerance to wait in A.
         The explanation can be found in the IE manual.
-        
+
         :param tolerance: The tolerance to wait until break, 0.01 = 1%.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_Toabs", tolerance)
-     
+
     def setIEOhmicDrop(self, ohmicdrop):
-        """ Set the ohmic drop for IE measurement.
-        
+        """Set the ohmic drop for IE measurement.
+
         :param ohmicdrop: The ohmic drop for measurement.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_Odrop", ohmicdrop)
-     
+
     def setIESweepMode(self, mode):
-        """ Set the sweep mode.
-         
+        """Set the sweep mode.
+
         The explanation of the modes can be found in the IE manual.
         mode="steady state"
         mode="fixed sampling"
         mode="dynamic scan"
-        
+
         :param mode: The sweep mode for measurement.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if mode == "steady state":
             mode = 0
         elif mode == "dynamic scan":
-            mode = 2        
+            mode = 2
         else:
             mode = 1
         return self.setValue("IE_SweepMode", mode)
-     
+
     def setIEScanRate(self, scanRate):
-        """ Set the scan rate.
-        
+        """Set the scan rate.
+
         This parameter is only used in sweep mode dynamic scan.
         The scan rate must be specified in V/s.
-        
+
         :param scanRate: The scan rate in V/s.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_Srate", scanRate)
-     
+
     def setIEMaximumCurrent(self, current):
-        """ Set the maximum current.
-        
+        """Set the maximum current.
+
         The maximum positive current at which the measurement is interrupted.
-        
+
         :param current: The maximum current for measurement in A.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_Ima", current)
-     
+
     def setIEMinimumCurrent(self, current):
-        """ Set the minimum current.
-         
+        """Set the minimum current.
+
         The maximum negative current at which the measurement is interrupted.
-        
+
         :param current: The minimum current for measurement in A.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_Imi", current)
-     
+
     def setIENaming(self, naming):
-        """ Set the IE measurement naming rule.
-         
+        """Set the IE measurement naming rule.
+
         naming = "dateTime": extend the :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setIEOutputFileName` with date and time.
         naming = "counter": extend the :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setIEOutputFileName` with an sequential number.
         naming = "individual": the file is named like :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.setIEOutputFileName`.
-        
+
         :param naming: The IE measurement naming rule.
         :type naming: string
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if naming == "dateTime":
@@ -1135,119 +1168,130 @@ class ThalesRemoteScriptWrapper(object):
         else:
             naming = 1
         return self.setValue("IE_MOD", naming)
-     
+
     def setIECounter(self, number):
-        """ Set the current number of IE measurement for filename.
-        
+        """Set the current number of IE measurement for filename.
+
         Current number for the file name for EIS measurements which is used next and then incremented.
-        
+
         :param number: The next measurement number.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_NUM", number)
-     
+
     def setIEOutputPath(self, path):
-        """ Set the path where the IE measurements should be stored.
-        
+        """Set the path where the IE measurements should be stored.
+
         The results must be stored on the C hard disk. If an error occurs test an alternative path or c:\THALES\temp.
         The directory must exist.
-        
+
         :param path: The path to the directory.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         path = path.lower()  # c: has to be lower case
         return self.setValue("IE_PATH", path)
-     
+
     def setIEOutputFileName(self, name):
-        """ Set the basic IE output filename.
-        
+        """Set the basic IE output filename.
+
         The basic name of the file, which is extended by a sequential number or the date and time.
         Only numbers, underscores and letters from a-Z may be used.
-        
+
         If the name is set to "individual", the file with the same name must not yet exist.
         Existing files are not overwritten.
-        
+
         :param name: The basic name of the file.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("IE_ROOT", name)
-     
+
     def checkIESetup(self):
-        """ Check the set parameters.
-         
+        """Check the set parameters.
+
         With the error number the wrong parameter can be found.
         The error numbers are listed in the Remote2 manual.
-        
-        :returns: The response string from the device.
+
+        :returns: reponse string from the device
         :rtype: string
         """
         reply = self.executeRemoteCommand("CHECKIE")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-     
+
     def readIESetup(self):
-        """ Read the set parameters.
-         
+        """Read the set parameters.
+
         After checking with :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.checkIESetup` the parameters can be read back from the workstation.
-        
-        :returns: The response string from the device.
+
+        :returns: reponse string from the device
         :rtype: string
         """
         reply = self.executeRemoteCommand("SENDIESETUP")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-     
+
     def measureIE(self):
-        """ Measure IE.
-         
+        """Measure IE.
+
         Before measurement, all parameters must be checked with :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.checkIESetup`.
-        
-        :returns: The response string from the device.
+
+        :returns: reponse string from the device
         :rtype: string
         """
         reply = self.executeRemoteCommand("IE")
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-     
+
     """
     Section of remote functions for the sequencer.
  
     With the sequencer DC profiles can be described textually.
     For instructions on how the sequencer file is structured, please refer to the manual of the sequencer.
     """
- 
+
     def selectSequence(self, number):
-        """ Select the sequence to run with runSequence().
-        
+        """Select the sequence to run with runSequence().
+
         The sequences must be stored under "C:\THALES\script\sequencer\sequences".
         Sequences from 0 to 9 can be created.
         These must have the names from "sequence00.seq" to "sequence09.seq".
-        
+
         :param number: The number of the sequence.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         reply = self.executeRemoteCommand("SELSEQ=" + str(number))
-        if(reply != "SELOK\r"):
-            raise ThalesRemoteError(reply.rstrip("\r") + " The selected sequence does not exist.")
+        if reply != "SELOK\r":
+            raise ThalesRemoteError(
+                reply.rstrip("\r") + " The selected sequence does not exist."
+            )
         return reply
-     
+
     def setSequenceNaming(self, naming):
-        """ Set the sequence measurement naming rule.
-        
+        """Set the sequence measurement naming rule.
+
         naming = "dateTime": extend the setSequenceOutputFileName(name) with date and time.
         naming = "counter": extend the setSequenceOutputFileName(name) with an sequential number.
         naming = "individual": the file is named like setEISOutputFileName(name).
-        
+
         :param naming: The naming rule.
         :type naming: string
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if naming == "dateTime":
@@ -1257,77 +1301,80 @@ class ThalesRemoteScriptWrapper(object):
         else:
             naming = 1
         return self.setValue("SEQ_MOD", naming)
-     
+
     def setSequenceCounter(self, number):
-        """ Set the current number of sequence measurement for filename.
-        
+        """Set the current number of sequence measurement for filename.
+
         Current number for the file name for EIS measurements which is used next and then incremented.
-        
+
         :param number: The next measurement number
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("SEQ_NUM", number)
-     
+
     def setSequenceOutputPath(self, path):
-        """ Set the path where the sequence measurements should be stored.
-        
+        """Set the path where the sequence measurements should be stored.
+
         The results must be stored on the C hard disk. If an error occurs test an alternative path or c:\THALES\temp.
         The directory must exist.
-        
+
         :param path: The path to the directory.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         path = path.lower()  # c: has to be lower case
         return self.setValue("SEQ_PATH", path)
-     
+
     def setSequenceOutputFileName(self, name):
-        """ Set the basic sequence output filename.
-        
+        """Set the basic sequence output filename.
+
         The basic name of the file, which is extended by a sequential number or the date and time.
         Only numbers, underscores and letters from a-Z may be used.
-        
+
         If the name is set to "individual", the file with the same name must not yet exist.
         Existing files are not overwritten.
-        
+
         :param name: The basic name of the file.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("SEQ_ROOT", name)
-     
+
     def runSequence(self):
-        """ Run the selected sequence.
-         
+        """Run the selected sequence.
+
         This command executes the selected sequence between 0 and 9.
-        
-        :returns: The response string from the device.
+
+        :returns: reponse string from the device
         :rtype: string
         """
         reply = self.executeRemoteCommand("DOSEQ")
-        if(reply != "SEQ DONE\r"):
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+        if reply != "SEQ DONE\r":
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-    
+
     def enableFraMode(self, state=True):
-        """ Enables the use of the FRA probe.
-        
+        """Enables the use of the FRA probe.
+
         With the FRA Probe, external power potentiostats, signal generators, sources, sinks can be
         controlled analog for impedance measurements.
-        
-        `FRA Product Page <https://zahner.de/products-details/probes/fra-probe>`_  
-        `FRA Manual <https://doc.zahner.de/hardware/fra_probe.pdf>`_  
-        
+
+        `FRA Product Page <https://zahner.de/products-details/probes/fra-probe>`_
+        `FRA Manual <https://doc.zahner.de/hardware/fra_probe.pdf>`_
+
         Before this function is called, the analog interface to the external interface must be initialized
         with the correct factors. It may be necessary to use + or - as sign, this must be tested to ensure
         that potentiostatic and galvanostatic function correctly.
-        
+
         For example, if the device has 100 A output current and the analog signal input range of the
         device is 5 V, then the current gain is 100/5.
-        
+
         :param state: If state = True FRA mode is enabled.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if state == True:
@@ -1335,99 +1382,99 @@ class ThalesRemoteScriptWrapper(object):
         else:
             state = 0
         return self.setValue("FRA", state)
-    
+
     def disableFraMode(self):
         return self.enableFraMode(False)
-    
+
     def setFraVoltageInputGain(self, value):
-        """ Sets the input voltage gain.
-        
+        """Sets the input voltage gain.
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_POT_IN", value)
-    
+
     def setFraVoltageOutputGain(self, value):
-        """ Sets the output voltage gain.
-        
+        """Sets the output voltage gain.
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_POT_OUT", value)
-    
+
     def setFraVoltageMinimum(self, value):
-        """ Sets the minimum voltage.
-        
+        """Sets the minimum voltage.
+
         Sets the minimum voltage of the FRA device.
-        
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_POT_MIN", value)
-    
+
     def setFraVoltageMaximum(self, value):
-        """ Sets the maximum voltage.
-        
+        """Sets the maximum voltage.
+
         Sets the maximum voltage of the FRA device.
-        
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_POT_MAX", value)
-    
+
     def setFraCurrentInputGain(self, value):
-        """ Sets the input current gain.
-        
+        """Sets the input current gain.
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_CUR_IN", value)
-    
+
     def setFraCurrentOutputGain(self, value):
-        """ Sets the output current gain.
-        
+        """Sets the output current gain.
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_CUR_OUT", value)
-    
+
     def setFraCurrentMinimum(self, value):
-        """ Sets the minimum current.
-        
+        """Sets the minimum current.
+
         Sets the minimum current of the FRA device.
-        
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_CUR_MIN", value)
-    
+
     def setFraCurrentMaximum(self, value):
-        """ Sets the maximum current.
-        
+        """Sets the maximum current.
+
         Sets the maximum current of the FRA device.
-        
+
         :param value: The value to set.
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         return self.setValue("FRA_CUR_MAX", value)
-     
+
     def setFraPotentiostatMode(self, potentiostatMode: PotentiostatMode):
-        """ Set the coupling of the FRA mode.
-         
+        """Set the coupling of the FRA mode.
+
         This can be PotentiostatMode.POTMODE_POTENTIOSTATIC or PotentiostatMode.POTMODE_GALVANOSTATIC or
         PotentiostatMode.POTMODE_PSEUDOGALVANOSTATIC.
-        
+
         :param potentiostatMode: The coupling of the FRA mode
         :type potentiostatMode: :class:`~thales_remote.script_wrapper.PotentiostatMode`
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if potentiostatMode == PotentiostatMode.POTMODE_POTENTIOSTATIC:
@@ -1437,19 +1484,23 @@ class ThalesRemoteScriptWrapper(object):
         else:
             return ""
         return self.executeRemoteCommand(command)
-        
-     
-    def runSequenceFile(self, filepath, sequence_folder="C:/THALES/script/sequencer/sequences", sequence_number=9):
-        """ Run the sequence at filepath.
-        
+
+    def runSequenceFile(
+        self,
+        filepath,
+        sequence_folder="C:/THALES/script/sequencer/sequences",
+        sequence_number=9,
+    ):
+        """Run the sequence at filepath.
+
         The file from the specified path is copied as sequence sequence_number=9 to the correct location in the Thales directory and then selected and executed.
         The default sequence number is 9 and does not need to be changed.
         The old sequence sequence_number is overwritten.
-        
+
         The variable sequence_folder is ONLY NECESSARY if python is running on ANOTHER COMPUTER like the one connected to the Zennium.
         For this the controlling computer must have access to the hard disk of the computer with the Zennium to access the THALES folder.
         In this case the path to the sequences folder in sequence_folder must be set to "C:/THALES/script/sequencer/sequences" on the computer with the zennium.
-        
+
         :param filepath: Filepath of the sequence.
         :type filepath: string
         :param sequence_folder: The filepath to the THALES sequence folder.
@@ -1458,132 +1509,148 @@ class ThalesRemoteScriptWrapper(object):
         :param sequence_number: The number in the THALES sequence directory.
             Does not normally need to be transferred and changed.
         :type sequence_number: int
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
         if sequence_number > 9 or sequence_number < 0:
             raise ThalesRemoteError("Wrong sequence number.")
-         
-        sequence_folder = sequence_folder + "/sequence{:02d}.seq".format(sequence_number)
-         
+
+        sequence_folder = sequence_folder + "/sequence{:02d}.seq".format(
+            sequence_number
+        )
+
         if filepath.find(".seq") < 0:
             raise ThalesRemoteError("Wrong sequence file extension.")
         if os.path.exists(sequence_folder):
             os.remove(sequence_folder)
         shutil.copy2(filepath, sequence_folder)
-         
+
         self.selectSequence(sequence_number)
-        return self.runSequence() 
-     
-    def setValue(self, name, value):
-        """ Set an Remote2 parameter or value.
-        
-        :param name: Name of the Remote2 parameter.
-        :type name: string
-        :param value: The value of the parameter.
-        :returns: The response string from the device.
-        :rtype: string
+        return self.runSequence()
+
+    def setValue(self, name: str, value: Union[int, float, str, Any]) -> str:
+        """
+        set an Remote2 parameter or value.
+
+        :param name: name of the Remote2 parameter
+        :param value: value of the parameter to set
+        :returns: response string from the device
         """
         if isinstance(value, float):
-            value = "{:.14e}".format(value)        
-        
+            value = "{:.14e}".format(value)
+
         reply = self.executeRemoteCommand(name + "=" + str(value))
-        if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+        if "ERROR" in reply:
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         return reply
-     
+
     def executeRemoteCommand(self, command):
-        """ Directly execute a query to Remote Script.
-        
+        """Directly execute a query to Remote Script.
+
         :param command: The command query string, e.g. "IMPEDANCE" or "Pset=0".
-        :returns: The response string from the device.
+        :returns: reponse string from the device
         :rtype: string
         """
-        return self.remoteConnection.sendStringAndWaitForReplyString("1:" + command + ":", 2)
-     
+        return self._remote_connection.sendStringAndWaitForReplyString(
+            "1:" + command + ":", 2
+        )
+
     def forceThalesIntoRemoteScript(self):
-        """ Prompts Thales to start the Remote Script.
-         
+        """Prompts Thales to start the Remote Script.
+
         Will switch a running Thales from anywhere like the main menu after
         startup to running measurements into Remote Script so it can process
         further requests.
-         
+
         .. note::
             This happens rather quickly if Thales is idle in main menu but
             may take some time if it's performing an EIS measurement or doing
             something else. For high stability applications 20 seconds would
             probably be a save bet.
-        
-        :returns: The response string from the device.
+
+        :returns: reponse string from the device
         :rtype: string
         """
-        self.remoteConnection.sendStringAndWaitForReplyString(f"3,{self.remoteConnection.getConnectionName()},0,OFF", 128)
-        return self.remoteConnection.sendStringAndWaitForReplyString(f"2,{self.remoteConnection.getConnectionName()}", 128)
-     
+        self._remote_connection.sendStringAndWaitForReplyString(
+            f"3,{self._remote_connection.getConnectionName()},0,OFF", 128
+        )
+        return self._remote_connection.sendStringAndWaitForReplyString(
+            f"2,{self._remote_connection.getConnectionName()}", 128
+        )
+
     def getWorkstationHeartBeat(self, timeout=None):
-        """ Query the heartbeat time from the Term software for the workstation and the Thales software accordingly.
-        
+        """Query the heartbeat time from the Term software for the workstation and the Thales software accordingly.
+
         The complete documentation can be found in the `DevCli-Manual <https://doc.zahner.de/manuals/devcli.pdf>`_ Page 8.
-         
-        
+
+
         The timeout is not set by default and the command blocks indefinitely.
         However, a time in seconds can optionally be specified for the timeout.
         When the timeout expires, an exception is thrown by the socket.
-        
+
         :param timeout: The time in seconds in which the term must provide the answer.
         :returns: The HeartBeat time in milli seconds.
         """
-        retval = self.remoteConnection.sendStringAndWaitForReplyString(f"1,{self.remoteConnection.getConnectionName()}", 128, timeout)
+        retval = self._remote_connection.sendStringAndWaitForReplyString(
+            f"1,{self._remote_connection.getConnectionName()}", 128, timeout
+        )
         return retval.split(",")[2]
-    
+
     def getSerialNumberFromTerm(self):
-        """ Get the serial number of the workstation via the Term software.
-        
+        """Get the serial number of the workstation via the Term software.
+
         The serial number of the active potentiostat with EPC devices can be read with the
         :func:`~thales_remote.script_wrapper.ThalesRemoteScriptWrapper.getSerialNumber` function.
         This function returns only the serial number of the workstation, which is determined by the Term software.
-        
+
         :returns: The workstation serial number.
         :rtype: string
         """
-        retval = self.remoteConnection.sendStringAndWaitForReplyString(f"3,{self.remoteConnection.getConnectionName()},6", 128)
-        return retval.split(",")[2]       
-    
+        retval = self._remote_connection.sendStringAndWaitForReplyString(
+            f"3,{self._remote_connection.getConnectionName()},6", 128
+        )
+        return retval.split(",")[2]
+
     def getTermIsActive(self, timeout=2):
-        """ Check if the Term still responds to requests.
-        
+        """Check if the Term still responds to requests.
+
         Whether the term is still active is checked by sending a heartbeat command.
         If the term does not respond after the timeout, an exception is thrown and this is caught with the except block.
         The time returned by getWorkstationHeartBeat is not relevant,
         it is only important that a response was returned within the time.
-        
+
         Afterwards False is returned if the exception was resolved.
         Once False is returned, the connection to the term MUST be completely re-established with
         connectToTerm and forceThalesIntoRemoteScript.
         The workstation must also be reset. To re-establish a controlled state.
-        
+
         :param timeout: Time in seconds in which the term must provide the answer, default 2 seconds.
         :returns: True or False if the Term is Active.
         :rtype: bool
         """
         active = True
         try:
-            self.remoteConnection.sendStringAndWaitForReplyString(f"1,{self.remoteConnection.getConnectionName()}", 128, timeout)
+            self._remote_connection.sendStringAndWaitForReplyString(
+                f"1,{self._remote_connection.getConnectionName()}", 128, timeout
+            )
         except:
             active = False
         return active
-    
+
     """
     The following methods should not be called by the user.
     They are marked with the prefix '_' after the Python convention for proteced.
     """
+
     def _requestValueAndParseUsingRegexp(self, command, pattern):
         reply = self.executeRemoteCommand(command)
         if reply.find("ERROR") >= 0:
-            raise ThalesRemoteError(reply.rstrip("\r") + ThalesRemoteScriptWrapper.undefindedStandardErrorString)
+            raise ThalesRemoteError(
+                reply.rstrip("\r")
+                + ThalesRemoteScriptWrapper.undefindedStandardErrorString
+            )
         match = re.search(pattern, reply)
         return float(match.group(1))
-
-
-
-


### PR DESCRIPTION
add type annotations and some formatting to thales_remote.{connecion,error,file_interface} and half way through script_wrapper

also:
- format code with "black"
- rename variables according to PEP8
- write comments which are not documentation as comments, not as docstrings
- replace "foo == None" with "foo is None"
- replace "if foo == True:" with "if foo:"
- sort import statements
- remove unused import statements
- remove underscore from "from _queue import Empty"
- replaced obscured calls to "return None" with literal statement, e.g.

```diff
  retval = None
  if some_condition:
-   return retval
+   return None
```

- added some TODOs
- fix typos in private attribute and method names (not in public interface)
- bugfix in ThalesFileInterface.appendFilesToSkip: properly handle both `str` and `list[str]`
- use context manager for file operations
- replace calls to `"foo".find("bar")` with `"bar" in "foo"`
- slightly improve docstrings
- use dict in ThalesRemoteScriptWrapper.setPotentiostatMode instead of elif-statements