### PR TITLE
make connection thread daemonic

### DIFF
--- a/thales_remote/connection.py
+++ b/thales_remote/connection.py
@@ -304,7 +304,9 @@ class ThalesRemoteConnection(object):
         starts the thread handling the asyncronously incoming data
         """
         self._receiving_worker_is_running = True
-        self._receiving_worker = threading.Thread(target=self._telegramListenerJob)
+        self._receiving_worker = threading.Thread(
+            target=self._telegramListenerJob, daemon=True
+        )
         self._receiving_worker.start()
         return
 


### PR DESCRIPTION
All my applications where I use the Python [`threading` library](https://docs.python.org/3/library/threading.html) show this weird behavior that they do not terminate properly even when the main thread stops. I am not sure since which Python version that problem occurs but it is super annoying and it also affects the `Thales-Remote-Python` library.

Stackoverflow got me covered:
https://stackoverflow.com/questions/12493467/python-threading-threads-do-not-close

This PR introduces one single change: it makes the thread spawned in the library daemonic which means that the applications terminates when the main thread terminates even if the library's thread still runs.

I think this is quite benefitial because terminating the thread by hand is not trivial and can not be expected from engineers who are not software developers at the same time. E.g. some users want to terminate their Python application with Ctrl+C and do not want to bother about other threads still running.
Also, calling `zenniumConnection.disconnectFromTerm()` does not work on my machine (never returns) but that is a different problem on its own.

I checked whether Thales works properly if the library's thread gets killed unexpectedly and Thales 5.9.1 continues to work just fine.